### PR TITLE
Track counter on playback screen

### DIFF
--- a/app/src/main/java/org/oxycblt/auxio/MainFragment.kt
+++ b/app/src/main/java/org/oxycblt/auxio/MainFragment.kt
@@ -31,12 +31,9 @@ import androidx.fragment.app.activityViewModels
 import androidx.navigation.NavController
 import androidx.navigation.NavDestination
 import androidx.navigation.findNavController
-import com.google.android.material.R as MR
 import com.google.android.material.bottomsheet.BackportBottomSheetBehavior
 import com.google.android.material.shape.MaterialShapeDrawable
 import dagger.hilt.android.AndroidEntryPoint
-import kotlin.math.max
-import kotlin.math.min
 import org.oxycblt.auxio.databinding.FragmentMainBinding
 import org.oxycblt.auxio.detail.DetailViewModel
 import org.oxycblt.auxio.list.ListViewModel
@@ -46,6 +43,7 @@ import org.oxycblt.auxio.playback.OpenPanel
 import org.oxycblt.auxio.playback.PlaybackBottomSheetBehavior
 import org.oxycblt.auxio.playback.PlaybackViewModel
 import org.oxycblt.auxio.playback.queue.QueueBottomSheetBehavior
+import org.oxycblt.auxio.playback.queue.QueueViewModel
 import org.oxycblt.auxio.ui.ViewBindingFragment
 import org.oxycblt.auxio.util.collectImmediately
 import org.oxycblt.auxio.util.context
@@ -55,6 +53,9 @@ import org.oxycblt.auxio.util.getDimen
 import org.oxycblt.auxio.util.logD
 import org.oxycblt.auxio.util.systemBarInsetsCompat
 import org.oxycblt.auxio.util.unlikelyToBeNull
+import kotlin.math.max
+import kotlin.math.min
+import com.google.android.material.R as MR
 
 /**
  * A wrapper around the home fragment that shows the playback fragment and high-level navigation.
@@ -69,6 +70,7 @@ class MainFragment :
     private val playbackModel: PlaybackViewModel by activityViewModels()
     private val listModel: ListViewModel by activityViewModels()
     private val detailModel: DetailViewModel by activityViewModels()
+    private val queueModel: QueueViewModel by activityViewModels()
     private var sheetBackCallback: SheetBackPressedCallback? = null
     private var detailBackCallback: DetailBackPressedCallback? = null
     private var selectionBackCallback: SelectionBackPressedCallback? = null
@@ -155,6 +157,7 @@ class MainFragment :
         collectImmediately(listModel.selected, selectionBackCallback::invalidateEnabled)
         collectImmediately(playbackModel.song, ::updateSong)
         collectImmediately(playbackModel.openPanel.flow, ::handlePanel)
+        collectImmediately(queueModel.index, queueModel.queueSize, ::updateQueuePosition)
     }
 
     override fun onStart() {
@@ -309,6 +312,15 @@ class MainFragment :
             OpenPanel.QUEUE -> tryOpenQueuePanel()
         }
         playbackModel.openPanel.consume()
+    }
+
+    private fun updateQueuePosition(index: Int, size: Int) {
+        requireBinding().queueTitle.text = getString(
+            R.string.fmt_label_with_counter,
+            getString(R.string.lbl_queue),
+            index + 1,
+            size
+        )
     }
 
     private fun tryOpenPlaybackPanel() {

--- a/app/src/main/java/org/oxycblt/auxio/playback/queue/QueueViewModel.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/queue/QueueViewModel.kt
@@ -19,10 +19,14 @@
 package org.oxycblt.auxio.playback.queue
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
 import javax.inject.Inject
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import org.oxycblt.auxio.list.adapter.UpdateInstructions
 import org.oxycblt.auxio.music.MusicParent
 import org.oxycblt.auxio.music.Song
@@ -55,6 +59,9 @@ class QueueViewModel @Inject constructor(private val playbackManager: PlaybackSt
     /** The index of the currently playing song in the queue. */
     val index: StateFlow<Int>
         get() = _index
+    /** Size of the current queue */
+    val queueSize: StateFlow<Int> =
+        _queue.map { it.size }.stateIn(viewModelScope, SharingStarted.Lazily, _queue.value.size)
 
     init {
         playbackManager.addListener(this)

--- a/app/src/main/res/layout-w600dp-land/fragment_main.xml
+++ b/app/src/main/res/layout-w600dp-land/fragment_main.xml
@@ -51,6 +51,7 @@
                 app:layout_constraintStart_toEndOf="@+id/playback_panel_fragment">
 
                 <TextView
+                    android:id="@+id/queue_title"
                     android:layout_width="match_parent"
                     android:layout_height="64dp"
                     android:gravity="center"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -391,6 +391,8 @@
     Do not use "and" or equivalents.
     -->
     <string name="fmt_list">%1$s, %2$s</string>
+    <!-- As in a label with position and total count -->
+    <string name="fmt_label_with_counter">%1$s (%2$d/%3$d)</string>
 
     <!-- As in an amount of items that are selected -->
     <string name="fmt_selected">%d Selected</string>


### PR DESCRIPTION
<!-- Please fill out all this information. -->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
Added simple track counter on playback screen. It shows current track position in queue and the queue size

#### Fixes the following issues
None

#### Any additional information
![Screenshot_20230714-123743~2](https://github.com/OxygenCobalt/Auxio/assets/8948226/92844335-3ef3-44e0-b573-187ea6db884e)


#### APK testing
I guess it is not necessary since the changes are very small

#### Due Diligence
- [x] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [x] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.