### PR TITLE
Fix Crashes/Bugs when Play Next is used at the end of a queue

### DIFF
--- a/app/src/main/java/org/oxycblt/auxio/playback/system/PlaybackService.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/system/PlaybackService.kt
@@ -377,7 +377,17 @@ class PlaybackService :
     }
 
     override fun playNext(songs: List<Song>, ack: StateAck.PlayNext) {
-        val nextIndex = player.nextMediaItemIndex
+        val currTimeline = player.currentTimeline
+        val nextIndex =
+            if (currTimeline.isEmpty) {
+                C.INDEX_UNSET
+            } else {
+                currTimeline.getNextWindowIndex(
+                    player.currentMediaItemIndex,
+                    Player.REPEAT_MODE_OFF,
+                    player.shuffleModeEnabled
+                )
+            }
 
         if (nextIndex == C.INDEX_UNSET) {
             player.addMediaItems(songs.map { it.toMediaItem() })

--- a/app/src/main/java/org/oxycblt/auxio/playback/system/PlaybackService.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/system/PlaybackService.kt
@@ -377,7 +377,14 @@ class PlaybackService :
     }
 
     override fun playNext(songs: List<Song>, ack: StateAck.PlayNext) {
-        player.addMediaItems(player.nextMediaItemIndex, songs.map { it.toMediaItem() })
+        val nextIndex = player.nextMediaItemIndex
+
+        if (nextIndex == C.INDEX_UNSET) {
+            player.addMediaItems(songs.map { it.toMediaItem() })
+        } else {
+            player.addMediaItems(nextIndex, songs.map { it.toMediaItem() })
+        }
+
         playbackManager.ack(this, ack)
         deferSave()
     }


### PR DESCRIPTION
<!-- Please fill out all this information. -->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
Handles the case where the next item index is `C.INDEX_UNSET`, adding the songs to the end of the queue instead of crashing.

Also fixes another bug that I found during my testing: if Play Next is used at the end of an index when Repeat All is enabled, Auxio wraps around and puts the songs at the start of the queue instead of the end. This ends up breaking the view model/queue display, as shown in the video below:

https://github.com/OxygenCobalt/Auxio/assets/163776820/fad247be-6ba2-4879-9b20-ef1939e86a06

The new approach should always fetch the next song as if Repeat is disabled, so instead of wrapping around you will just get `C.INDEX_UNSET` and Auxio should proceed as above. 

#### Fixes the following issues
#735 

#### APK testing
<!-- Please create a debug APK for your changes, if possible. -->

[debug.zip](https://github.com/OxygenCobalt/Auxio/files/14805634/debug.zip)

#### Due Diligence
- [x] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [x] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.