### PR TITLE
feat: add implementation of name sorting with transliteration

### DIFF
--- a/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/Naming.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/Naming.kt
@@ -15,9 +15,11 @@
  * You should have received a copy of the GNU General Public License
  * along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
- 
+
 package org.oxycblt.musikr.tag.interpret
 
+import android.icu.text.Transliterator
+import android.os.Build
 import java.text.CollationKey
 import java.text.Collator
 import org.oxycblt.musikr.tag.Name
@@ -84,7 +86,7 @@ private data class IntelligentKnownName(override val raw: String, override val s
     private fun parseTokens(name: String): List<Token> {
         // TODO: This routine is consuming much of the song building runtime, find a way to
         //  optimize it
-        val stripped =
+        var stripped =
             name
                 // Remove excess punctuation from the string, as those usually aren't
                 // considered in sorting.
@@ -100,6 +102,13 @@ private data class IntelligentKnownName(override val raw: String, override val s
                         else -> this
                     }
                 }
+
+        // Transliterate to latin if available
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && Transliterator.getAvailableIDs()
+                .toList().contains("Any-Latin")
+        ) {
+            stripped = Transliterator.getInstance("Any-Latin;").transliterate(stripped)
+        }
 
         // To properly compare numeric components in names, we have to split them up into
         // individual lexicographic and numeric tokens and then individually compare them


### PR DESCRIPTION
<!-- Please fill out all this information. -->

#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
Adds a simple transliteration step in the sorting process (if supported by the device, requires Android 10 or higher), allowing for more natural sorting (eg. names in other languages will be placed approximately on how they're pronounced)

#### Fixes the following issues
Fixes #1110 

#### Any additional information
I took the liberty to add the code to the `Naming` class to group it with the intelligent sorting, avoiding any disruption with what some users would expect from "simple" sorting

#### APK testing
<!-- Please create a debug APK for your changes, if possible. -->
[app-debug.zip](https://github.com/user-attachments/files/20541773/app-debug.zip)

#### Due Diligence
- [x] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [x] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.