### PR TITLE
feat: share songs in album order

### DIFF
--- a/app/src/main/java/org/oxycblt/auxio/util/FrameworkUtil.kt
+++ b/app/src/main/java/org/oxycblt/auxio/util/FrameworkUtil.kt
@@ -44,9 +44,9 @@ import androidx.viewbinding.ViewBinding
 import com.google.android.material.appbar.MaterialToolbar
 import java.lang.IllegalArgumentException
 import org.oxycblt.auxio.R
+import org.oxycblt.musikr.Album
 import org.oxycblt.musikr.MusicParent
 import org.oxycblt.musikr.Song
-import org.oxycblt.musikr.Album
 import timber.log.Timber as L
 
 /**
@@ -304,14 +304,12 @@ fun Context.share(song: Song) = share(listOf(song))
 fun Context.share(parent: MusicParent) {
     if (parent is Album) {
         // share songs in album order
-        val sorted = parent.songs.sortedWith(
-            compareBy({ it.disc ?: 0 }, { it.track ?: 0 }))
+        val sorted = parent.songs.sortedWith(compareBy({ it.disc ?: 0 }, { it.track ?: 0 }))
         share(sorted)
     } else {
         share(parent.songs)
     }
 }
-
 
 /**
  * Share an arbitrary list of [Song]s.

--- a/app/src/main/java/org/oxycblt/auxio/util/FrameworkUtil.kt
+++ b/app/src/main/java/org/oxycblt/auxio/util/FrameworkUtil.kt
@@ -46,6 +46,7 @@ import java.lang.IllegalArgumentException
 import org.oxycblt.auxio.R
 import org.oxycblt.musikr.MusicParent
 import org.oxycblt.musikr.Song
+import org.oxycblt.musikr.Album
 import timber.log.Timber as L
 
 /**
@@ -300,7 +301,17 @@ fun Context.share(song: Song) = share(listOf(song))
  *
  * @param parent The [MusicParent] to share.
  */
-fun Context.share(parent: MusicParent) = share(parent.songs)
+fun Context.share(parent: MusicParent) {
+    if (parent is Album) {
+        // share songs in album order
+        val sorted = parent.songs.sortedWith(
+            compareBy({ it.disc ?: 0 }, { it.track ?: 0 }))
+        share(sorted)
+    } else {
+        share(parent.songs)
+    }
+}
+
 
 /**
  * Share an arbitrary list of [Song]s.


### PR DESCRIPTION
#### What is it?
- [ ] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes

When sharing an album (and _only_ when sharing an album), Auxio now shares the songs in album order.

The reasoning here is that if a user shares an album to an other app, such as a streaming app, the user probably wants that app to play/consume these tracks in album order. Before this change, the order appeared random on the end of the receiving app.  

I've thought about adding sorting to other types of `MusicParent`, but they all lack a natural ordening, IMO.

#### Fixes the following issues
Somewhat related to https://github.com/OxygenCobalt/Auxio/issues/379.  I've wanted to switch to Auxio for a long time (to go 100% FOSS), but I'm incredibly accustomed to casting stuff from my phone. 

Then I realized that since Auxio can share collections of files to Kore (a [Kodi](https://kodi.tv/) remote app), and since Kore can in turn stream files over http to Kodi, you basically have rudimentary FOSS casting.

In my test, this whole chain works pretty great!

~~For the whole plan to go through, however, the Kore devs  still need to approve a pull request  (https://github.com/xbmc/Kore/pull/1043).~~ (relevant external PR was merged)

#### Any additional information
Thanks for developing Auxio!

#### APK testing
[app-debug.apk.zip](https://github.com/user-attachments/files/21815525/app-debug.apk.zip)

#### Due Diligence
- [x] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [x] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.