### PR TITLE
Align fast scroll indicator with thumb top

### DIFF
--- a/app/src/main/java/org/oxycblt/auxio/list/recycler/FastScrollRecyclerView.kt
+++ b/app/src/main/java/org/oxycblt/auxio/list/recycler/FastScrollRecyclerView.kt
@@ -305,10 +305,9 @@ constructor(context: Context, attrs: AttributeSet? = null, @AttrRes defStyleAttr
             }
 
         val popupAnchorY = popupHeight / 2
-        val thumbAnchorY = thumbView.height / 2
 
         val popupTop =
-            (thumbTop + thumbAnchorY - popupAnchorY)
+            (thumbTop - popupAnchorY)
                 .coerceAtLeast(thumbPadding.top + popupLayoutParams.topMargin)
                 .coerceAtMost(
                     height - thumbPadding.bottom - popupLayoutParams.bottomMargin - popupHeight)


### PR DESCRIPTION
## Summary
- align the fast scroll indicator popup so its center lines up with the thumb's top edge

## Testing
- not run (not run)


------
https://chatgpt.com/codex/tasks/task_e_68f27158b0b48325bdbee501720a1e41