### PR TITLE
Emit SAF files after directory enumeration

### DIFF
--- a/musikr/src/main/java/org/oxycblt/musikr/fs/saf/SAF.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/fs/saf/SAF.kt
@@ -150,11 +150,12 @@ private constructor(
                                         NullAddedMs
                                     })
                         children.add(file)
-                        files.send(file)
                     }
                 }
-                directoryDeferred.complete(Directory(uri, relativePath, parent, children))
             }
+            val directory = Directory(uri, relativePath, parent, children)
+            directoryDeferred.complete(directory)
+            children.forEach { file -> files.send(file) }
             recursive.tryAwaitAll()
         }
 


### PR DESCRIPTION
## Summary
- emit SAF directory children only after enumeration completes so each file observes a resolved parent

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe6b8cee0083259796c73a7ba25c7f