### PR TITLE
Remap composer metadata to artist fields

### DIFF
--- a/musikr/src/main/java/org/oxycblt/musikr/tag/parse/TagFields.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/parse/TagFields.kt
@@ -152,6 +152,43 @@ internal fun Metadata.artistSortNames() =
         ?: id3v2["TXXX:ARTISTSORT"]
         ?: id3v2["TXXX:ARTIST SORT"])
 
+internal fun Metadata.composerMusicBrainzIds() =
+    (xiph["MUSICBRAINZ_COMPOSERID"]
+        ?: xiph["MUSICBRAINZ COMPOSER ID"]
+        ?: mp4["----:COM.APPLE.ITUNES:MUSICBRAINZ COMPOSER ID"]
+        ?: mp4["----:COM.APPLE.ITUNES:MUSICBRAINZ_COMPOSERID"]
+        ?: id3v2["TXXX:MUSICBRAINZ COMPOSER ID"]
+        ?: id3v2["TXXX:MUSICBRAINZ_COMPOSERID"])
+
+internal fun Metadata.composerNames() =
+    (xiph["COMPOSERS"]
+        ?: xiph["COMPOSER"]
+        ?: mp4["----:COM.APPLE.ITUNES:COMPOSERS"]
+        ?: mp4["----:COM.APPLE.ITUNES:COMPOSER"]
+        ?: mp4["©wrt"]
+        ?: id3v2["TXXX:COMPOSERS"]
+        ?: id3v2["TCOM"]
+        ?: id3v2["TXXX:COMPOSER"])
+
+internal fun Metadata.composerSortNames() =
+    (xiph["COMPOSERSSORT"]
+        ?: xiph["COMPOSERS_SORT"]
+        ?: xiph["COMPOSERS SORT"]
+        ?: xiph["COMPOSERSORT"]
+        ?: xiph["COMPOSER SORT"]
+        ?: mp4["----:COM.APPLE.ITUNES:COMPOSERSSORT"]
+        ?: mp4["----:COM.APPLE.ITUNES:COMPOSERS_SORT"]
+        ?: mp4["----:COM.APPLE.ITUNES:COMPOSERS SORT"]
+        ?: mp4["----:COM.APPLE.ITUNES:COMPOSERSORT"]
+        ?: mp4["soCo"]
+        ?: mp4["----:COM.APPLE.ITUNES:COMPOSER SORT"]
+        ?: id3v2["TXXX:COMPOSERSSORT"]
+        ?: id3v2["TXXX:COMPOSERS_SORT"]
+        ?: id3v2["TXXX:COMPOSERS SORT"]
+        ?: id3v2["TXXX:COMPOSERSORT"]
+        ?: id3v2["TSOC"]
+        ?: id3v2["TXXX:COMPOSER SORT"])
+
 internal fun Metadata.albumArtistMusicBrainzIds() =
     (xiph["MUSICBRAINZ_ALBUMARTISTID"]
         ?: xiph["MUSICBRAINZ ALBUM ARTIST ID"]

--- a/musikr/src/main/java/org/oxycblt/musikr/tag/parse/TagParser.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/parse/TagParser.kt
@@ -31,6 +31,14 @@ internal interface TagParser {
 private data object TagParserImpl : TagParser {
     override fun parse(metadata: Metadata): ParsedTags {
         val compilation = metadata.isCompilation()
+        val artistMusicBrainzIds =
+            metadata.artistMusicBrainzIds()
+                ?: metadata.composerMusicBrainzIds()
+                ?: listOf()
+        val artistNames =
+            metadata.artistNames() ?: metadata.composerNames() ?: listOf()
+        val artistSortNames =
+            metadata.artistSortNames() ?: metadata.composerSortNames() ?: listOf()
         return ParsedTags(
             durationMs = metadata.properties.durationMs,
             replayGainTrackAdjustment = metadata.replayGainTrackAdjustment(),
@@ -49,9 +57,9 @@ private data object TagParserImpl : TagParser {
             // we don't have any other release types
             releaseTypes =
                 metadata.releaseTypes() ?: listOf("compilation").takeIf { compilation } ?: listOf(),
-            artistMusicBrainzIds = metadata.artistMusicBrainzIds() ?: listOf(),
-            artistNames = metadata.artistNames() ?: listOf(),
-            artistSortNames = metadata.artistSortNames() ?: listOf(),
+            artistMusicBrainzIds = artistMusicBrainzIds,
+            artistNames = artistNames,
+            artistSortNames = artistSortNames,
             albumArtistMusicBrainzIds = metadata.albumArtistMusicBrainzIds() ?: listOf(),
             // Compilation pretty heavily implies various artists in the case that we don't
             // have any other album artists

--- a/musikr/src/test/java/org/oxycblt/musikr/tag/parse/TagParserTest.kt
+++ b/musikr/src/test/java/org/oxycblt/musikr/tag/parse/TagParserTest.kt
@@ -145,6 +145,23 @@ class TagParserTest {
         assertEquals(-2.1f, tags.replayGainAlbumAdjustment)
     }
 
+    @Test
+    fun tagParser_composerFallbackForArtistInfo() {
+        val metadata =
+            createTestMetadata(
+                id3v2Tags =
+                    mapOf(
+                        "TCOM" to listOf("Composer Artist"),
+                        "TSOC" to listOf("Composer Artist Sort"),
+                        "TXXX:MUSICBRAINZ COMPOSER ID" to listOf("composer-artist-mbid")))
+
+        val tags = tagParser.parse(metadata)
+
+        assertEquals(listOf("Composer Artist"), tags.artistNames)
+        assertEquals(listOf("Composer Artist Sort"), tags.artistSortNames)
+        assertEquals(listOf("composer-artist-mbid"), tags.artistMusicBrainzIds)
+    }
+
     private fun createTestMetadata(
         id3v2Tags: Map<String, List<String>> = emptyMap(),
         xiphTags: Map<String, List<String>> = emptyMap(),


### PR DESCRIPTION
## Summary
- treat composer tag metadata as artist equivalents for names, sort names, and MusicBrainz IDs during tag parsing when dedicated artist fields are absent
- add unit coverage confirming the composer fallback behaviour in TagParser

## Testing
- ./gradlew --offline --console=plain musikr:testDebug *(fails: SDK location not found. Define a valid SDK location with an ANDROID_HOME environment variable or by setting the sdk.dir path in local.properties.)*

------
https://chatgpt.com/codex/tasks/task_e_690844608e608325a9bf9d12af8823e7