### PR TITLE
Changed behavior for interpeter, if empty do not make placeholder

### DIFF
--- a/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/TagInterpreter.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/TagInterpreter.kt
@@ -61,7 +61,7 @@ private class TagInterpreterImpl(private val interpretation: Interpretation) : T
         val rawArtists =
             individualPreArtists.ifEmpty { albumPreArtists }.ifEmpty { listOf(unknownPreArtist()) }
         val rawGenres =
-            makePreGenres(song.tags, interpretation).ifEmpty { listOf(unknownPreGenre()) }
+            makePreGenres(song.tags, interpretation)
         val uri = song.file.uri
 
         val songNameOrFile = song.tags.name ?: requireNotNull(song.file.path.name)


### PR DESCRIPTION
<!-- Please fill out all this information. -->

#### What is it?
- [ ] Bugfix (user facing)
- [X] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
<!-- Bullet points or free-form text -->
- Changed the behavior of taginterpreter
- If an empty list of genre is found, do not create a placeholder "Unknown Genre"

#### Fixes the following issues
Issue #1171: Suppressing "Unknown Genre"

#### Any additional information
Was unable to test on my system, SO PLEASE DISREGARD PR 
 |                                                                                                    |
V                                                                                                   V
Reviewing this repository was for a class, so I had to create a PR for a requirement

#### APK testing
<!-- Please create a debug APK for your changes, if possible. -->
N/A

#### Due Diligence
- [X ] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [X] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.