### PR TITLE
Fix playback not resuming after error on malformed files

### DIFF
--- a/app/src/main/java/org/oxycblt/auxio/playback/service/ExoPlaybackStateHolder.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/service/ExoPlaybackStateHolder.kt
@@ -524,6 +524,7 @@ class ExoPlaybackStateHolder(
         // If there's any issue, just go to the next song.
         L.e("Player error occurred")
         L.e(error.stackTraceToString())
+        player.prepare()
         playbackManager.next()
     }
 


### PR DESCRIPTION
<!-- Please fill out all this information. -->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
<!-- Bullet points or free-form text -->
Call player.prepare() before skipping on error.
Previously, when ExoPlayer encountered a malformed file, it entered ERROR state 
and got stuck, next() moved the queue but playback did not resume.

#### Fixes the following issues
<!-- Also add any other links relevant to your change. -->
Fixes #1261 

#### Any additional information
<!-- Also add any information relevant to this PR. -->
The file in #1261 is a Youtube Dash m4a (mp4 audio) file, according to
mp4 spec, ID3 box goes inside meta box if present, but in this case
it was added before ftyp box, which TagLib does not handle either
(see [TagLib's mp4file.cpp](https://github.com/taglib/taglib/blob/9c042984d26af605a6fd1dac7f12bda05219fee7/taglib/mp4/mp4file.cpp#L59)).

An ID3 box in an mp4 file is very rare, but it does exist,
just not supposed to be in the order that the broken file had.

We should not attempt to fix these files, as it encourages bad files,
leading to further issues, however I will leave that decision up to @OxygenCobalt 

#### APK testing
<!-- Please create a debug APK for your changes, if possible. -->
[Auxio_Canary.zip](https://github.com/user-attachments/files/24520008/Auxio_Canary.zip)
sha256:d904a20ad0932654ed8c301bb11ec95afc969b4a0bd105d8059eefcabdbbad6c

#### Due Diligence
- [x] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [x] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.