### PR TITLE
Fix notification large icon not updating when null

### DIFF
--- a/app/src/main/java/org/oxycblt/auxio/playback/service/MediaSessionHolder.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/service/MediaSessionHolder.kt
@@ -446,7 +446,14 @@ private class PlaybackNotification(
      */
     fun updateMetadata(metadata: MediaMetadataCompat) {
         L.d("Updating shown metadata")
-        setLargeIcon(metadata.getBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART))
+        val albumArt = metadata.getBitmap(MediaMetadataCompat.METADATA_KEY_ALBUM_ART)
+        if (albumArt != null) {
+            setLargeIcon(albumArt)
+        } else {
+            // setLargeIcon(null) doesn't reliably clear the icon on all devices.
+            // Use a transparent 1x1 bitmap instead.
+            setLargeIcon(EMPTY_BITMAP)
+        }
         setContentTitle(metadata.getString(MediaMetadataCompat.METADATA_KEY_TITLE))
         setContentText(metadata.getText(MediaMetadataCompat.METADATA_KEY_ARTIST))
         setSubText(metadata.getText(MediaMetadataCompat.METADATA_KEY_DISPLAY_DESCRIPTION))
@@ -534,5 +541,8 @@ private class PlaybackNotification(
                 id = BuildConfig.APPLICATION_ID + ".channel.PLAYBACK",
                 nameRes = R.string.lbl_playback,
             )
+
+        /** Cached 1x1 transparent bitmap. */
+        private val EMPTY_BITMAP: Bitmap = Bitmap.createBitmap(1, 1, Bitmap.Config.ARGB_8888)
     }
 }


### PR DESCRIPTION
<!-- Please fill out all this information. -->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
<!-- Bullet points or free-form text -->
setLargeIcon(null) doesn't reliably clear the icon on all devices.
So, we use a transparent 1x1 bitmap instead.

#### Fixes the following issues
<!-- Also add any other links relevant to your change. -->
Fixes #1179 

#### Any additional information
<!-- Also add any information relevant to this PR. -->
This is a software-level fix to a problem presumably caused by the system handling the large icon differently on certain devices.
(The bug was observed on a Redmi 7 running Android 9).
Currently, using a transparent Bitmap instead of null should not have any side effects, but further testing might be needed for cases where it looks odd or causes problems.

#### APK testing
<!-- Please create a debug APK for your changes, if possible. -->
[Auxio_Canary.zip](https://github.com/user-attachments/files/24548835/Auxio_Canary.zip)
sha256:9da4796a24f7071d1f0817f616f57f0aab1572c359bea598e1d66ef60570f690

#### Due Diligence
- [x] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [x] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.