### PR TITLE
Fix incomplete close & Add playback stop switch

### DIFF
--- a/app/src/main/java/org/oxycblt/auxio/AuxioService.kt
+++ b/app/src/main/java/org/oxycblt/auxio/AuxioService.kt
@@ -152,6 +152,11 @@ class AuxioService :
                 } else {
                     ServiceCompat.stopForeground(this, ServiceCompat.STOP_FOREGROUND_REMOVE)
                     isForeground = false
+
+                    if (playbackFragment.shouldStopService) {
+                        Timber.d("Exit requested, stopping service")
+                        stopSelf()
+                    }
                 }
             }
         }

--- a/app/src/main/java/org/oxycblt/auxio/playback/PlaybackSettings.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/PlaybackSettings.kt
@@ -60,6 +60,8 @@ interface PlaybackSettings : Settings<PlaybackSettings.Listener> {
     val pauseOnRepeat: Boolean
     /** Whether to maintain the play/pause state when skipping or editing the queue */
     val rememberPause: Boolean
+    /** Whether to always exit when task is removed, even if playing. */
+    val exitOnTaskRemoval: Boolean
 
     interface Listener {
         /** Called when one of the ReplayGain configurations have changed. */
@@ -142,6 +144,9 @@ class PlaybackSettingsImpl @Inject constructor(@ApplicationContext context: Cont
 
     override val rememberPause: Boolean
         get() = sharedPreferences.getBoolean(getString(R.string.set_key_remember_pause), false)
+
+    override val exitOnTaskRemoval: Boolean
+        get() = sharedPreferences.getBoolean(getString(R.string.set_key_task_exit), false)
 
     override fun migrate() {
         // MusicMode was converted to PlaySong in 3.2.0

--- a/app/src/main/java/org/oxycblt/auxio/playback/PlaybackSettings.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/PlaybackSettings.kt
@@ -37,8 +37,6 @@ import timber.log.Timber as L
 interface PlaybackSettings : Settings<PlaybackSettings.Listener> {
     /** The action to display on the playback bar. */
     val barAction: ActionMode
-    /** The action to display in the playback notification. */
-    val notificationAction: ActionMode
     /** Whether to start playback when a headset is plugged in. */
     val headsetAutoplay: Boolean
     /** The current ReplayGain configuration. */
@@ -66,9 +64,6 @@ interface PlaybackSettings : Settings<PlaybackSettings.Listener> {
     interface Listener {
         /** Called when one of the ReplayGain configurations have changed. */
         fun onReplayGainSettingsChanged() {}
-
-        /** Called when [notificationAction] has changed. */
-        fun onNotificationActionChanged() {}
 
         /** Called when [barAction] has changed. */
         fun onBarActionChanged() {}
@@ -103,12 +98,6 @@ class PlaybackSettingsImpl @Inject constructor(@ApplicationContext context: Cont
             ActionMode.fromIntCode(
                 sharedPreferences.getInt(getString(R.string.set_key_bar_action), Int.MIN_VALUE)
             ) ?: ActionMode.NEXT
-
-    override val notificationAction: ActionMode
-        get() =
-            ActionMode.fromIntCode(
-                sharedPreferences.getInt(getString(R.string.set_key_notif_action), Int.MIN_VALUE)
-            ) ?: ActionMode.REPEAT
 
     override val headsetAutoplay: Boolean
         get() = sharedPreferences.getBoolean(getString(R.string.set_key_headset_autoplay), false)
@@ -203,10 +192,6 @@ class PlaybackSettingsImpl @Inject constructor(@ApplicationContext context: Cont
             getString(R.string.set_key_pre_amp_without) -> {
                 L.d("Dispatching ReplayGain setting change")
                 listener.onReplayGainSettingsChanged()
-            }
-            getString(R.string.set_key_notif_action) -> {
-                L.d("Dispatching notification setting change")
-                listener.onNotificationActionChanged()
             }
             getString(R.string.set_key_bar_action) -> {
                 L.d("Dispatching bar action change")

--- a/app/src/main/java/org/oxycblt/auxio/playback/service/MediaSessionHolder.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/service/MediaSessionHolder.kt
@@ -42,8 +42,6 @@ import org.oxycblt.auxio.music.resolve
 import org.oxycblt.auxio.music.resolveNames
 import org.oxycblt.auxio.music.service.MediaSessionUID
 import org.oxycblt.auxio.music.service.toMediaDescription
-import org.oxycblt.auxio.playback.ActionMode
-import org.oxycblt.auxio.playback.PlaybackSettings
 import org.oxycblt.auxio.playback.state.PlaybackStateManager
 import org.oxycblt.auxio.playback.state.Progression
 import org.oxycblt.auxio.playback.state.QueueChange
@@ -65,17 +63,15 @@ private constructor(
     private val context: Context,
     private val foregroundListener: ForegroundListener,
     private val playbackManager: PlaybackStateManager,
-    private val playbackSettings: PlaybackSettings,
     private val bitmapProvider: BitmapProvider,
     private val imageSettings: ImageSettings,
     private val mediaSessionInterface: MediaSessionInterface,
-) : PlaybackStateManager.Listener, ImageSettings.Listener, PlaybackSettings.Listener {
+) : PlaybackStateManager.Listener, ImageSettings.Listener {
 
     class Factory
     @Inject
     constructor(
         private val playbackManager: PlaybackStateManager,
-        private val playbackSettings: PlaybackSettings,
         private val bitmapProvider: BitmapProvider,
         private val imageSettings: ImageSettings,
         private val mediaSessionInterface: MediaSessionInterface,
@@ -85,7 +81,6 @@ private constructor(
                 context,
                 foregroundListener,
                 playbackManager,
-                playbackSettings,
                 bitmapProvider,
                 imageSettings,
                 mediaSessionInterface,
@@ -102,7 +97,6 @@ private constructor(
 
     fun attach() {
         playbackManager.addListener(this)
-        playbackSettings.registerListener(this)
         imageSettings.registerListener(this)
         mediaSession.apply {
             isActive = true
@@ -121,7 +115,6 @@ private constructor(
     fun release() {
         bitmapProvider.release()
         playbackManager.removeListener(this)
-        playbackSettings.unregisterListener(this)
         imageSettings.unregisterListener(this)
         mediaSession.apply {
             isActive = false
@@ -159,7 +152,7 @@ private constructor(
                 PlaybackStateCompat.SHUFFLE_MODE_NONE
             }
         )
-        invalidateSecondaryAction()
+        invalidateNotificationActions()
     }
 
     override fun onNewPlayback(
@@ -190,7 +183,7 @@ private constructor(
             }
         )
 
-        invalidateSecondaryAction()
+        invalidateNotificationActions()
     }
 
     // --- SETTINGS OVERRIDES ---
@@ -198,11 +191,6 @@ private constructor(
     override fun onImageSettingsChanged() {
         // Need to reload the metadata cover.
         updateMediaMetadata(playbackManager.currentSong, playbackManager.parent)
-    }
-
-    override fun onNotificationActionChanged() {
-        // Need to re-load the action shown in the notification.
-        invalidateSecondaryAction()
     }
 
     // --- MEDIASESSION OVERRIDES ---
@@ -334,60 +322,40 @@ private constructor(
 
         // Android 13+ relies on custom actions in the notification.
 
-        // Add the secondary action (either repeat/shuffle depending on the configuration)
-        val secondaryAction =
-            when (playbackSettings.notificationAction) {
-                ActionMode.SHUFFLE -> {
-                    L.d("Using shuffle MediaSession action")
-                    PlaybackStateCompat.CustomAction.Builder(
-                        PlaybackActions.ACTION_INVERT_SHUFFLE,
-                        context.getString(R.string.desc_shuffle),
-                        if (playbackManager.isShuffled) {
-                            R.drawable.ic_shuffle_on_24
-                        } else {
-                            R.drawable.ic_shuffle_off_24
-                        },
-                    )
-                }
-                else -> {
-                    L.d("Using repeat mode MediaSession action")
-                    PlaybackStateCompat.CustomAction.Builder(
-                        PlaybackActions.ACTION_INC_REPEAT_MODE,
-                        context.getString(R.string.desc_change_repeat),
-                        playbackManager.repeatMode.icon,
-                    )
-                }
-            }
-        state.addCustomAction(secondaryAction.build())
-
-        // Add the exit action so the service can be closed
-        val exitAction =
+        // Add repeat action
+        val repeatAction =
             PlaybackStateCompat.CustomAction.Builder(
-                    PlaybackActions.ACTION_EXIT,
-                    context.getString(R.string.desc_exit),
-                    R.drawable.ic_close_24,
+                    PlaybackActions.ACTION_INC_REPEAT_MODE,
+                    context.getString(R.string.desc_change_repeat),
+                    playbackManager.repeatMode.icon,
                 )
                 .build()
-        state.addCustomAction(exitAction)
+        state.addCustomAction(repeatAction)
+
+        // Add shuffle action
+        val shuffleAction =
+            PlaybackStateCompat.CustomAction.Builder(
+                    PlaybackActions.ACTION_INVERT_SHUFFLE,
+                    context.getString(R.string.desc_shuffle),
+                    if (playbackManager.isShuffled) {
+                        R.drawable.ic_shuffle_on_24
+                    } else {
+                        R.drawable.ic_shuffle_off_24
+                    },
+                )
+                .build()
+        state.addCustomAction(shuffleAction)
 
         mediaSession.setPlaybackState(state.build())
     }
 
-    /** Invalidate the "secondary" action (i.e shuffle/repeat mode). */
-    private fun invalidateSecondaryAction() {
-        L.d("Invalidating secondary action")
+    /** Invalidate both repeat and shuffle notification actions. */
+    private fun invalidateNotificationActions() {
+        L.d("Invalidating notification actions")
         invalidateSessionState()
 
-        when (playbackSettings.notificationAction) {
-            ActionMode.SHUFFLE -> {
-                L.d("Using shuffle notification action")
-                _notification.updateShuffled(playbackManager.isShuffled)
-            }
-            else -> {
-                L.d("Using repeat mode notification action")
-                _notification.updateRepeatMode(playbackManager.repeatMode)
-            }
-        }
+        _notification.updateRepeatMode(playbackManager.repeatMode)
+        _notification.updateShuffled(playbackManager.isShuffled)
 
         if (!bitmapProvider.isBusy) {
             L.d("Not loading a bitmap, post the notification")
@@ -427,7 +395,7 @@ private class PlaybackNotification(
         addAction(
             buildAction(context, PlaybackActions.ACTION_SKIP_NEXT, R.drawable.ic_skip_next_24)
         )
-        addAction(buildAction(context, PlaybackActions.ACTION_EXIT, R.drawable.ic_close_24))
+        addAction(buildShuffleAction(context, false))
 
         setStyle(
             MediaStyle(this).setMediaSession(sessionToken).setShowActionsInCompactView(1, 2, 3)
@@ -486,7 +454,7 @@ private class PlaybackNotification(
      */
     fun updateShuffled(isShuffled: Boolean) {
         L.d("Applying shuffle action: $isShuffled")
-        mActions[0] = buildShuffleAction(context, isShuffled)
+        mActions[4] = buildShuffleAction(context, isShuffled)
     }
 
     // --- NOTIFICATION ACTION BUILDERS ---

--- a/app/src/main/java/org/oxycblt/auxio/playback/service/PlaybackServiceFragment.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/service/PlaybackServiceFragment.kt
@@ -18,6 +18,7 @@
  
 package org.oxycblt.auxio.playback.service
 
+import android.app.ActivityManager
 import android.content.Context
 import android.content.Intent
 import android.support.v4.media.session.MediaSessionCompat
@@ -27,16 +28,20 @@ import org.oxycblt.auxio.AuxioService.Companion.INTENT_KEY_START_ID
 import org.oxycblt.auxio.ForegroundListener
 import org.oxycblt.auxio.ForegroundServiceNotification
 import org.oxycblt.auxio.IntegerTable
+import org.oxycblt.auxio.playback.PlaybackSettings
 import org.oxycblt.auxio.playback.state.DeferredPlayback
 import org.oxycblt.auxio.playback.state.PlaybackStateManager
 import org.oxycblt.auxio.widgets.WidgetComponent
+import org.oxycblt.musikr.MusicParent
+import org.oxycblt.musikr.Song
 import timber.log.Timber as L
 
 class PlaybackServiceFragment
 private constructor(
-    context: Context,
+    private val context: Context,
     private val foregroundListener: ForegroundListener,
     private val playbackManager: PlaybackStateManager,
+    private val playbackSettings: PlaybackSettings,
     exoHolderFactory: ExoPlaybackStateHolder.Factory,
     sessionHolderFactory: MediaSessionHolder.Factory,
     widgetComponentFactory: WidgetComponent.Factory,
@@ -46,6 +51,7 @@ private constructor(
     @Inject
     constructor(
         private val playbackManager: PlaybackStateManager,
+        private val playbackSettings: PlaybackSettings,
         private val exoHolderFactory: ExoPlaybackStateHolder.Factory,
         private val sessionHolderFactory: MediaSessionHolder.Factory,
         private val widgetComponentFactory: WidgetComponent.Factory,
@@ -56,6 +62,7 @@ private constructor(
                 context,
                 foregroundListener,
                 playbackManager,
+                playbackSettings,
                 exoHolderFactory,
                 sessionHolderFactory,
                 widgetComponentFactory,
@@ -67,7 +74,44 @@ private constructor(
     private val exoHolder = exoHolderFactory.create()
     private val sessionHolder = sessionHolderFactory.create(context, foregroundListener)
     private val widgetComponent = widgetComponentFactory.create(context)
-    private val systemReceiver = systemReceiverFactory.create(context, widgetComponent)
+    private val activityManager =
+        context.getSystemService(Context.ACTIVITY_SERVICE) as ActivityManager
+    private val systemReceiver =
+        systemReceiverFactory.create(
+            context,
+            widgetComponent,
+            onExitRequested = { handleExitRequest() },
+        )
+
+    // Tracks whether an intentional exit has been requested.
+    private var exitRequested = false
+
+    private fun isAppForegrounded(): Boolean {
+        val processes = activityManager.runningAppProcesses ?: return false
+        val pkg = context.packageName
+        val own = processes.find { it.processName == pkg } ?: return false
+        val imp = own.importance
+        val visible =
+            // IMPORTANCE_FOREGROUND (100): Process in foreground UI, user is interacting.
+            // IMPORTANCE_VISIBLE (200): Process visible, but not in immediate foreground.
+            imp == ActivityManager.RunningAppProcessInfo.IMPORTANCE_FOREGROUND ||
+                imp == ActivityManager.RunningAppProcessInfo.IMPORTANCE_VISIBLE
+        L.d("Importance: $imp, visible: $visible")
+        return visible
+    }
+
+    private fun handleExitRequest() {
+        if (isAppForegrounded()) {
+            // (x) in notification will no longer exist, but it might still
+            // be triggered by other ways, e.g. Bluetooth devices.
+            L.d("Exit Requested: App visible, pausing")
+            playbackManager.playing(false)
+        } else {
+            L.d("Exit Requested: App not visible, exiting")
+            exitRequested = true
+            playbackManager.endSession()
+        }
+    }
 
     // --- MEDIASESSION CALLBACKS ---
 
@@ -81,7 +125,11 @@ private constructor(
     }
 
     fun handleTaskRemoved() {
-        if (!playbackManager.progression.isPlaying) {
+        val shouldExit =
+            !playbackManager.progression.isPlaying || playbackSettings.exitOnTaskRemoval
+
+        if (shouldExit) {
+            exitRequested = true
             playbackManager.endSession()
         }
     }
@@ -128,6 +176,9 @@ private constructor(
     val notification: ForegroundServiceNotification?
         get() = if (exoHolder.sessionOngoing) sessionHolder.notification else null
 
+    val shouldStopService: Boolean
+        get() = exitRequested && !exoHolder.sessionOngoing
+
     fun release() {
         waitJob.cancel()
         playbackManager.removeListener(this)
@@ -135,6 +186,15 @@ private constructor(
         widgetComponent.release()
         sessionHolder.release()
         exoHolder.release()
+    }
+
+    override fun onNewPlayback(
+        parent: MusicParent?,
+        queue: List<Song>,
+        index: Int,
+        isShuffled: Boolean,
+    ) {
+        exitRequested = false
     }
 
     override fun onSessionEnded() {

--- a/app/src/main/java/org/oxycblt/auxio/playback/service/PlaybackServiceFragment.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/service/PlaybackServiceFragment.kt
@@ -23,7 +23,11 @@ import android.content.Context
 import android.content.Intent
 import android.support.v4.media.session.MediaSessionCompat
 import javax.inject.Inject
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import org.oxycblt.auxio.AuxioService.Companion.INTENT_KEY_START_ID
 import org.oxycblt.auxio.ForegroundListener
 import org.oxycblt.auxio.ForegroundServiceNotification
@@ -31,6 +35,7 @@ import org.oxycblt.auxio.IntegerTable
 import org.oxycblt.auxio.playback.PlaybackSettings
 import org.oxycblt.auxio.playback.state.DeferredPlayback
 import org.oxycblt.auxio.playback.state.PlaybackStateManager
+import org.oxycblt.auxio.playback.state.Progression
 import org.oxycblt.auxio.widgets.WidgetComponent
 import org.oxycblt.musikr.MusicParent
 import org.oxycblt.musikr.Song
@@ -71,6 +76,8 @@ private constructor(
     }
 
     private val waitJob = Job()
+    private val scope = CoroutineScope(Dispatchers.Main + waitJob)
+    private var autoStopJob: Job? = null
     private val exoHolder = exoHolderFactory.create()
     private val sessionHolder = sessionHolderFactory.create(context, foregroundListener)
     private val widgetComponent = widgetComponentFactory.create(context)
@@ -101,15 +108,39 @@ private constructor(
     }
 
     private fun handleExitRequest() {
-        if (isAppForegrounded()) {
-            // (x) in notification no longer exists, but it might still
-            // be triggered by other ways, e.g. Bluetooth devices.
-            L.d("Exit Requested: App visible, pausing")
-            playbackManager.playing(false)
-        } else {
-            L.d("Exit Requested: App not visible, exiting")
-            exitRequested = true
-            playbackManager.endSession()
+        val foregrounded = isAppForegrounded()
+        exitRequested = !foregrounded
+        L.d("Exit requested: foregrounded=$foregrounded, exitRequested=$exitRequested")
+        // possibly redundant?
+        // although endSession() should end up calling scheduleAutoStop() due to
+        // onProgressionChanged() override, we use it just to be safe, in case it is
+        // not called if the state was already paused.
+        scheduleAutoStop()
+        playbackManager.endSession()
+    }
+
+    private fun scheduleAutoStop() {
+        autoStopJob?.cancel()
+        autoStopJob =
+            scope.launch {
+                delay(AUTO_STOP_DELAY_MS)
+                L.d(
+                    "Auto-stop timer expired after ${AUTO_STOP_DELAY_MS / 60000} minutes of inactivity"
+                )
+                handleExitRequest()
+            }
+    }
+
+    private fun cancelAutoStop() {
+        autoStopJob?.cancel()
+        autoStopJob = null
+    }
+
+    private fun updateAutoStopTimer(isPlaying: Boolean) {
+        if (isPlaying) {
+            cancelAutoStop()
+        } else if (playbackManager.currentSong != null) {
+            scheduleAutoStop()
         }
     }
 
@@ -121,6 +152,7 @@ private constructor(
         widgetComponent.attach()
         systemReceiver.attach()
         playbackManager.addListener(this)
+        updateAutoStopTimer(playbackManager.progression.isPlaying)
         return sessionHolder.token
     }
 
@@ -180,6 +212,7 @@ private constructor(
         get() = exitRequested && !exoHolder.sessionOngoing
 
     fun release() {
+        autoStopJob?.cancel()
         waitJob.cancel()
         playbackManager.removeListener(this)
         systemReceiver.release()
@@ -195,9 +228,19 @@ private constructor(
         isShuffled: Boolean,
     ) {
         exitRequested = false
+        cancelAutoStop()
+    }
+
+    override fun onProgressionChanged(progression: Progression) {
+        // Update timer whenever play/pause state changes
+        updateAutoStopTimer(progression.isPlaying)
     }
 
     override fun onSessionEnded() {
         foregroundListener.updateForeground(ForegroundListener.Change.MEDIA_SESSION)
+    }
+
+    private companion object {
+        private const val AUTO_STOP_DELAY_MS = 30L * 60L * 1000L
     }
 }

--- a/app/src/main/java/org/oxycblt/auxio/playback/service/PlaybackServiceFragment.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/service/PlaybackServiceFragment.kt
@@ -102,7 +102,7 @@ private constructor(
 
     private fun handleExitRequest() {
         if (isAppForegrounded()) {
-            // (x) in notification will no longer exist, but it might still
+            // (x) in notification no longer exists, but it might still
             // be triggered by other ways, e.g. Bluetooth devices.
             L.d("Exit Requested: App visible, pausing")
             playbackManager.playing(false)

--- a/app/src/main/java/org/oxycblt/auxio/playback/service/SystemPlaybackReceiver.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/service/SystemPlaybackReceiver.kt
@@ -41,6 +41,7 @@ private constructor(
     private val playbackManager: PlaybackStateManager,
     private val playbackSettings: PlaybackSettings,
     private val widgetComponent: WidgetComponent,
+    private val onExitRequested: () -> Unit,
 ) : BroadcastReceiver() {
     private var initialHeadsetPlugEventHandled = false
 
@@ -50,8 +51,18 @@ private constructor(
         private val playbackManager: PlaybackStateManager,
         private val playbackSettings: PlaybackSettings,
     ) {
-        fun create(context: Context, widgetComponent: WidgetComponent) =
-            SystemPlaybackReceiver(context, playbackManager, playbackSettings, widgetComponent)
+        fun create(
+            context: Context,
+            widgetComponent: WidgetComponent,
+            onExitRequested: () -> Unit,
+        ) =
+            SystemPlaybackReceiver(
+                context,
+                playbackManager,
+                playbackSettings,
+                widgetComponent,
+                onExitRequested,
+            )
     }
 
     @Suppress("WrongConstant")
@@ -116,7 +127,7 @@ private constructor(
             }
             PlaybackActions.ACTION_EXIT -> {
                 L.d("Received exit event")
-                playbackManager.endSession()
+                onExitRequested()
             }
             WidgetProvider.ACTION_WIDGET_UPDATE -> {
                 L.d("Received widget update event")

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -49,6 +49,8 @@
 
     <string name="set_key_search_filter_to" translatable="false">KEY_SEARCH_FILTER</string>
 
+    <string name="set_key_task_exit" translatable="false">auxio_task_exit</string>
+
     <string name="set_key_songs_sort" translatable="false">auxio_songs_sort</string>
     <string name="set_key_albums_sort" translatable="false">auxio_albums_sort</string>
     <string name="set_key_artists_sort" translatable="false">auxio_artists_sort</string>

--- a/app/src/main/res/values/settings.xml
+++ b/app/src/main/res/values/settings.xml
@@ -45,7 +45,6 @@
     <string name="set_key_hide_collaborators" translatable="false">auxio_hide_collaborators</string>
     <string name="set_key_round_mode" translatable="false">auxio_round_covers</string>
     <string name="set_key_bar_action" translatable="false">auxio_bar_action</string>
-    <string name="set_key_notif_action" translatable="false">auxio_notif_action</string>
 
     <string name="set_key_search_filter_to" translatable="false">KEY_SEARCH_FILTER</string>
 
@@ -107,16 +106,6 @@
 
     <integer-array name="values_bar_action">
         <item>@integer/action_mode_next</item>
-        <item>@integer/action_mode_repeat</item>
-        <item>@integer/action_mode_shuffle</item>
-    </integer-array>
-
-    <integer-array name="entries_notif_action">
-        <item>@string/set_action_mode_repeat</item>
-        <item>@string/lbl_shuffle</item>
-    </integer-array>
-
-    <integer-array name="values_notif_action">
         <item>@integer/action_mode_repeat</item>
         <item>@integer/action_mode_shuffle</item>
     </integer-array>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -260,6 +260,8 @@
     <string name="set_play_song_by_itself">Play song by itself</string>
     <string name="set_keep_shuffle">Remember shuffle</string>
     <string name="set_keep_shuffle_desc">Keep shuffle on when playing a new song</string>
+    <string name="set_task_exit">Always exit on close</string>
+    <string name="set_task_exit_desc">Stop playback when removed from recents, even if playing</string>
 
     <string name="set_content">Content</string>
     <string name="set_content_desc">Control how music and images are loaded</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -246,7 +246,6 @@
     <string name="set_lib_tabs_desc">Change visibility and order of library tabs</string>
     <!-- Skip to next (song) -->
     <string name="set_bar_action">Custom playback bar action</string>
-    <string name="set_notif_action">Custom notification action</string>
     <string name="set_action_mode_next">Skip to next</string>
     <string name="set_action_mode_repeat">Repeat mode</string>
     <string name="set_behavior">Behavior</string>

--- a/app/src/main/res/xml/preferences_personalize.xml
+++ b/app/src/main/res/xml/preferences_personalize.xml
@@ -50,6 +50,12 @@
             app:summary="@string/set_keep_shuffle_desc"
             app:title="@string/set_keep_shuffle" />
 
+        <SwitchPreferenceCompat
+            app:defaultValue="false"
+            app:key="@string/set_key_task_exit"
+            app:summary="@string/set_task_exit_desc"
+            app:title="@string/set_task_exit" />
+
     </PreferenceCategory>
 
 

--- a/app/src/main/res/xml/preferences_personalize.xml
+++ b/app/src/main/res/xml/preferences_personalize.xml
@@ -17,13 +17,6 @@
             app:key="@string/set_key_bar_action"
             app:title="@string/set_bar_action" />
 
-        <org.oxycblt.auxio.settings.ui.IntListPreference
-            app:defaultValue="@integer/action_mode_repeat"
-            app:entries="@array/entries_notif_action"
-            app:entryValues="@array/values_notif_action"
-            app:key="@string/set_key_notif_action"
-            app:title="@string/set_notif_action" />
-
     </PreferenceCategory>
 
     <PreferenceCategory android:title="@string/set_behavior">


### PR DESCRIPTION
<!-- Please fill out all this information. -->

#### What is it?
- [x] Bugfix (user facing)
- [x] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
<!-- Bullet points or free-form text -->
- Fixes the app not exiting properly when pressing X in the notification.
Before this, the OS had to kill it after ~1 minute.
- Adds "Always exit on close" setting (off by default). When enabled,
swiping from recents kills playback even if music is playing.
Find it in [Settings] -> [Personalize] -> [Behavior] -> [Always exit on close]
- (x) button now checks if the app is visible. If you're looking at the app,
it just pauses instead of force-closing the app.
- If the app is in the background, it exits properly.
- Calls stopSelf() when exit is actually requested, so the service shuts down cleanly.
- Resets the exit flag when new playback starts, so things don't get stuck in a weird state.

#### Fixes the following issues
<!-- Also add any other links relevant to your change. -->
#1195 

#### Any additional information
<!-- Also add any information relevant to this PR. -->
Tested across multiple scenarios to verify behavior. When the X button is pressed in the notification, the app checks process importance to determine if the UI is visible to the user (foreground activity, split-screen, PiP, etc). If the UI is visible, playback pauses rather than force-closing the app. If the app is in the background (home screen, recents, Android Auto with phone screen off), it exits cleanly and calls stopSelf().

For recents swipe behavior: if playback is paused, the service exits. If playback is active, it only exits when the "always exit on close" setting is enabled. Otherwise playback continues in the background as expected.

The exit flag resets when new playback starts, ensuring that starting a new song before the service shuts down cancels the pending exit. Also handles edge cases including runningAppProcesses returning null (defaults to exit as a safe fallback) and foreground service protection during low memory conditions.

Android Auto scenarios weren't directly tested but should work based on the importance-level logic. Further testing on actual Android Auto hardware would be helpful.

#### APK testing
<!-- Please create a debug APK for your changes, if possible. -->
[Auxio_Canary.zip](https://github.com/user-attachments/files/24672608/Auxio_Canary.zip)
sha256:9191b7296a4d634e4105bfbe51b664e1f592b0ef6869a4a6555b2d441ce72843

#### Due diligence
- [x] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [x] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.