### PR TITLE
musikr: stable playlist song identity across UID changes

### DIFF
--- a/musikr/src/main/java/org/oxycblt/musikr/Music.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/Music.kt
@@ -117,6 +117,9 @@ sealed interface Music {
 
             /** @see musicBrainz */
             MUSICBRAINZ("org.musicbrainz", 'm'),
+
+            /** @see acoustid */
+            ACOUSTID("org.acoustid", 'c'),
         }
 
         object TypeConverters {
@@ -194,6 +197,46 @@ sealed interface Music {
             internal fun musicBrainz(item: Item, mbid: UUID) = UID(Format.MUSICBRAINZ, item, mbid)
 
             /**
+             * Creates an AcoustID-style [UID] with a [UUID] derived by SHA-256 hashing the AcoustID
+             * fingerprint string extracted from a file. More stable than any metadata-based UID
+             * because it reflects audio content rather than tags.
+             *
+             * @param item The [Item] that created this [UID].
+             * @param fingerprint The raw AcoustID fingerprint string extracted from the file.
+             * @return A new AcoustID-style [UID].
+             */
+            internal fun acoustid(item: Item, fingerprint: String): UID {
+                val digest =
+                    MessageDigest.getInstance("SHA-256")
+                        .apply { update(fingerprint.toByteArray(Charsets.UTF_8)) }
+                        .digest()
+                val uuid =
+                    UUID(
+                        digest[0]
+                            .toLong()
+                            .shl(56)
+                            .or(digest[1].toLong().and(0xFF).shl(48))
+                            .or(digest[2].toLong().and(0xFF).shl(40))
+                            .or(digest[3].toLong().and(0xFF).shl(32))
+                            .or(digest[4].toLong().and(0xFF).shl(24))
+                            .or(digest[5].toLong().and(0xFF).shl(16))
+                            .or(digest[6].toLong().and(0xFF).shl(8))
+                            .or(digest[7].toLong().and(0xFF)),
+                        digest[8]
+                            .toLong()
+                            .shl(56)
+                            .or(digest[9].toLong().and(0xFF).shl(48))
+                            .or(digest[10].toLong().and(0xFF).shl(40))
+                            .or(digest[11].toLong().and(0xFF).shl(32))
+                            .or(digest[12].toLong().and(0xFF).shl(24))
+                            .or(digest[13].toLong().and(0xFF).shl(16))
+                            .or(digest[14].toLong().and(0xFF).shl(8))
+                            .or(digest[15].toLong().and(0xFF)),
+                    )
+                return UID(Format.ACOUSTID, item, uuid)
+            }
+
+            /**
              * Convert a [UID]'s string representation back into a concrete [UID] instance.
              *
              * @param uid The [UID]'s string representation, formatted as
@@ -208,6 +251,7 @@ sealed interface Music {
                         when (uid.getOrNull(1)) {
                             Format.AUXIO.microNamespace -> Format.AUXIO
                             Format.MUSICBRAINZ.microNamespace -> Format.MUSICBRAINZ
+                            Format.ACOUSTID.microNamespace -> Format.ACOUSTID
                             else -> return null
                         }
                     val microItem =
@@ -235,6 +279,7 @@ sealed interface Music {
                     when (split[0]) {
                         Format.AUXIO.namespace -> Format.AUXIO
                         Format.MUSICBRAINZ.namespace -> Format.MUSICBRAINZ
+                        Format.ACOUSTID.namespace -> Format.ACOUSTID
                         else -> return null
                     }
 

--- a/musikr/src/main/java/org/oxycblt/musikr/graph/MusicGraph.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/graph/MusicGraph.kt
@@ -36,6 +36,10 @@ internal data class MusicGraph(
     val artistVertex: List<ArtistVertex>,
     val genreVertex: List<GenreVertex>,
     val playlistVertex: Set<PlaylistVertex>,
+    /** Old hash UIDs → new MusicBrainz UIDs for songs that gained a MusicBrainz ID since the last
+     * index run. Populated during playlist resolution whenever a legacy UID matched a stored
+     * playlist entry. Used to update the playlist DB so future runs resolve cleanly. */
+    val uidMigrations: Map<Music.UID, Music.UID>,
 ) {
     interface Builder {
         fun add(preSong: PreSong)
@@ -184,6 +188,7 @@ private class MusicGraphBuilderImpl : MusicGraph.Builder {
     private val artistVertices = mutableMapOf<PreArtist, ArtistVertex>()
     private val genreVertices = mutableMapOf<PreGenre, GenreVertex>()
     private val playlistVertices = mutableSetOf<PlaylistVertex>()
+    private val uidMigrations = mutableMapOf<Music.UID, Music.UID>()
 
     override fun add(preSong: PreSong) {
         val uid = preSong.v363Uid
@@ -314,6 +319,19 @@ private class MusicGraphBuilderImpl : MusicGraph.Builder {
                 it.pointerMap[v400Pointer]?.forEach { index -> it.songVertices[index] = vertex }
                 val v401Pointer = SongPointer.UID(entry.value.preSong.v401Uid)
                 it.pointerMap[v401Pointer]?.forEach { index -> it.songVertices[index] = vertex }
+
+                // Probe hash UIDs the song carried before gaining a MusicBrainz ID. If any
+                // playlist still references the old hash UID, resolve it now and record the
+                // migration so the DB can be updated to the canonical MusicBrainz UID.
+                for (legacyUid in entry.value.preSong.legacyUids) {
+                    val legacyPointer = SongPointer.UID(legacyUid)
+                    if (it.pointerMap[legacyPointer] != null) {
+                        it.pointerMap[legacyPointer]!!.forEach { index ->
+                            it.songVertices[index] = vertex
+                        }
+                        uidMigrations[legacyUid] = entry.key
+                    }
+                }
             }
         }
 
@@ -324,6 +342,7 @@ private class MusicGraphBuilderImpl : MusicGraph.Builder {
                 artistVertices.values.toList(),
                 genreVertices.values.toList(),
                 playlistVertices,
+                uidMigrations,
             )
 
         return graph

--- a/musikr/src/main/java/org/oxycblt/musikr/graph/MusicGraph.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/graph/MusicGraph.kt
@@ -43,6 +43,30 @@ internal data class MusicGraph(
      */
     val uidMigrations: Map<Music.UID, Music.UID>,
 ) {
+    /**
+     * Re-resolve playlist vertices for any songs whose UID changed after the graph was built. The
+     * URI-index migrations are computed after [build] returns, so they can't be applied during the
+     * normal resolution pass. Calling this before [org.oxycblt.musikr.model.LibraryFactory.create]
+     * ensures the current rescan reflects the correct playlist contents immediately rather than
+     * requiring a second rescan.
+     *
+     * @param migrations Map of old UID → new UID, as produced by
+     *   [org.oxycblt.musikr.playlist.db.StoredPlaylists.computeUriMigrations].
+     */
+    fun applyMigrations(migrations: Map<Music.UID, Music.UID>) {
+        if (migrations.isEmpty()) return
+        val uidToVertex = songVertex.associateBy { it.preSong.v363Uid }
+        for (playlist in playlistVertex) {
+            for ((oldUid, newUid) in migrations) {
+                val indices = playlist.pointerMap[SongPointer.UID(oldUid)] ?: continue
+                val vertex = uidToVertex[newUid] ?: continue
+                for (index in indices) {
+                    playlist.songVertices[index] = vertex
+                }
+            }
+        }
+    }
+
     interface Builder {
         fun add(preSong: PreSong)
 

--- a/musikr/src/main/java/org/oxycblt/musikr/graph/MusicGraph.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/graph/MusicGraph.kt
@@ -36,9 +36,11 @@ internal data class MusicGraph(
     val artistVertex: List<ArtistVertex>,
     val genreVertex: List<GenreVertex>,
     val playlistVertex: Set<PlaylistVertex>,
-    /** Old hash UIDs → new MusicBrainz UIDs for songs that gained a MusicBrainz ID since the last
+    /**
+     * Old hash UIDs → new MusicBrainz UIDs for songs that gained a MusicBrainz ID since the last
      * index run. Populated during playlist resolution whenever a legacy UID matched a stored
-     * playlist entry. Used to update the playlist DB so future runs resolve cleanly. */
+     * playlist entry. Used to update the playlist DB so future runs resolve cleanly.
+     */
     val uidMigrations: Map<Music.UID, Music.UID>,
 ) {
     interface Builder {

--- a/musikr/src/main/java/org/oxycblt/musikr/pipeline/EvaluateStep.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/pipeline/EvaluateStep.kt
@@ -65,9 +65,22 @@ private class EvaluateStepImpl(
         }
         val graph = builder.build()
 
-        // Migrate playlist DB entries for songs whose UID changed from hash to MusicBrainz.
-        // This runs after every index but is a no-op when no songs have changed UID.
-        storedPlaylists.migrate(graph.uidMigrations)
+        // Build the uri → uid map for every song in this index run.
+        val currentUriToUid =
+            graph.songVertex.associate { it.preSong.uri.toString() to it.preSong.v363Uid }
+
+        // Collect UID migrations from two sources and apply them together:
+        //  1. legacyUids probe: hash UIDs the song carried before gaining a MusicBrainz ID
+        //     (handles the "only MB ID added, other tags unchanged" case without a prior URI
+        // record).
+        //  2. URI index diff: any song whose file URI was previously mapped to a different UID
+        //     (handles tag changes, MB ID + tag changes together, or any other UID drift).
+        val uriMigrations = storedPlaylists.computeUriMigrations(currentUriToUid)
+        val allMigrations = graph.uidMigrations + uriMigrations
+        storedPlaylists.migrate(allMigrations)
+
+        // Persist the current uri → uid mapping so the next run can detect further UID changes.
+        storedPlaylists.updateUriIndex(currentUriToUid)
 
         // Render graph to Graphviz in debug mode
         if (BuildConfig.DEBUG) {

--- a/musikr/src/main/java/org/oxycblt/musikr/pipeline/EvaluateStep.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/pipeline/EvaluateStep.kt
@@ -82,6 +82,12 @@ private class EvaluateStepImpl(
         // Persist the current uri → uid mapping so the next run can detect further UID changes.
         storedPlaylists.updateUriIndex(currentUriToUid)
 
+        // Apply URI migrations to the in-memory graph so the current rescan shows correct playlist
+        // contents immediately. The graph was built before migrations were computed (the DB still
+        // had old UIDs when PlaylistVertex.pointerMap was populated), so without this songs whose
+        // UID changed this run would appear missing until a second rescan.
+        graph.applyMigrations(uriMigrations)
+
         // Render graph to Graphviz in debug mode
         if (BuildConfig.DEBUG) {
             try {

--- a/musikr/src/main/java/org/oxycblt/musikr/pipeline/EvaluateStep.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/pipeline/EvaluateStep.kt
@@ -65,6 +65,10 @@ private class EvaluateStepImpl(
         }
         val graph = builder.build()
 
+        // Migrate playlist DB entries for songs whose UID changed from hash to MusicBrainz.
+        // This runs after every index but is a no-op when no songs have changed UID.
+        storedPlaylists.migrate(graph.uidMigrations)
+
         // Render graph to Graphviz in debug mode
         if (BuildConfig.DEBUG) {
             try {

--- a/musikr/src/main/java/org/oxycblt/musikr/playlist/db/PlaylistDatabase.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/playlist/db/PlaylistDatabase.kt
@@ -28,6 +28,8 @@ import androidx.room.Room
 import androidx.room.RoomDatabase
 import androidx.room.Transaction
 import androidx.room.TypeConverters
+import androidx.room.migration.Migration
+import androidx.sqlite.db.SupportSQLiteDatabase
 import org.oxycblt.musikr.Music
 
 /**
@@ -36,8 +38,14 @@ import org.oxycblt.musikr.Music
  * @author Alexander Capehart (OxygenCobalt)
  */
 @Database(
-    entities = [PlaylistInfo::class, PlaylistSong::class, PlaylistSongCrossRef::class],
-    version = 30,
+    entities =
+        [
+            PlaylistInfo::class,
+            PlaylistSong::class,
+            PlaylistSongCrossRef::class,
+            SongUriRecord::class,
+        ],
+    version = 31,
     exportSchema = false,
 )
 @TypeConverters(Music.UID.TypeConverters::class)
@@ -51,10 +59,21 @@ internal abstract class PlaylistDatabase : RoomDatabase() {
                     PlaylistDatabase::class.java,
                     "user_music.db",
                 )
+                .addMigrations(MIGRATION_30_31)
                 .fallbackToDestructiveMigration(true)
                 .build()
     }
 }
+
+private val MIGRATION_30_31 =
+    object : Migration(30, 31) {
+        override fun migrate(db: SupportSQLiteDatabase) {
+            db.execSQL(
+                "CREATE TABLE IF NOT EXISTS `SongUriRecord` " +
+                    "(`uri` TEXT NOT NULL, `songUid` TEXT NOT NULL, PRIMARY KEY(`uri`))"
+            )
+        }
+    }
 
 // TODO: Handle playlist defragmentation? I really don't want dead songs to accumulate in this
 //  database.
@@ -187,4 +206,29 @@ internal abstract class PlaylistDao {
     /** Internal, do not use. */
     @Query("DELETE FROM PlaylistSong WHERE songUid = :songUid")
     abstract suspend fun deleteSong(songUid: Music.UID)
+
+    /**
+     * Read the full URI → UID index recorded after the last index run.
+     *
+     * @return All [SongUriRecord] entries currently stored.
+     */
+    @Query("SELECT * FROM SongUriRecord") abstract suspend fun readUriRecords(): List<SongUriRecord>
+
+    /**
+     * Replace the entire URI → UID index with the current song set.
+     *
+     * @param records The new [SongUriRecord] entries representing every indexed song.
+     */
+    @Transaction
+    open suspend fun replaceUriIndex(records: List<SongUriRecord>) {
+        clearUriRecords()
+        insertUriRecords(records)
+    }
+
+    /** Internal, do not use. */
+    @Query("DELETE FROM SongUriRecord") abstract suspend fun clearUriRecords()
+
+    /** Internal, do not use. */
+    @Insert(onConflict = OnConflictStrategy.REPLACE)
+    abstract suspend fun insertUriRecords(records: List<SongUriRecord>)
 }

--- a/musikr/src/main/java/org/oxycblt/musikr/playlist/db/PlaylistDatabase.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/playlist/db/PlaylistDatabase.kt
@@ -165,4 +165,26 @@ internal abstract class PlaylistDao {
     /** Internal, do not use. */
     @Query("DELETE FROM PlaylistSongCrossRef where playlistUid = :playlistUid")
     abstract suspend fun deleteRefs(playlistUid: Music.UID)
+
+    /**
+     * Migrate all playlist references from [oldUid] to [newUid]. Used when a song gains a
+     * MusicBrainz ID and its canonical UID changes from a hash-based UID to a MusicBrainz UID.
+     *
+     * @param oldUid The hash-based [Music.UID] previously stored in playlists.
+     * @param newUid The MusicBrainz [Music.UID] that now identifies the same song.
+     */
+    @Transaction
+    open suspend fun migrateSongUid(oldUid: Music.UID, newUid: Music.UID) {
+        insertSongs(listOf(PlaylistSong(newUid)))
+        updateCrossRefSongUid(oldUid, newUid)
+        deleteSong(oldUid)
+    }
+
+    /** Internal, do not use. */
+    @Query("UPDATE PlaylistSongCrossRef SET songUid = :newUid WHERE songUid = :oldUid")
+    abstract suspend fun updateCrossRefSongUid(oldUid: Music.UID, newUid: Music.UID)
+
+    /** Internal, do not use. */
+    @Query("DELETE FROM PlaylistSong WHERE songUid = :songUid")
+    abstract suspend fun deleteSong(songUid: Music.UID)
 }

--- a/musikr/src/main/java/org/oxycblt/musikr/playlist/db/RawPlaylist.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/playlist/db/RawPlaylist.kt
@@ -66,3 +66,10 @@ internal data class PlaylistSongCrossRef(
     @ColumnInfo(index = true) val playlistUid: Music.UID,
     @ColumnInfo(index = true) val songUid: Music.UID,
 )
+
+/**
+ * Maps a song's file URI to its last-known [Music.UID]. Updated after every index run so that any
+ * subsequent tag changes (including gaining a MusicBrainz ID) can be detected and the corresponding
+ * playlist entries migrated to the new UID.
+ */
+@Entity internal data class SongUriRecord(@PrimaryKey val uri: String, val songUid: Music.UID)

--- a/musikr/src/main/java/org/oxycblt/musikr/playlist/db/StoredPlaylists.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/playlist/db/StoredPlaylists.kt
@@ -30,6 +30,8 @@ abstract class StoredPlaylists {
 
     internal abstract suspend fun read(): List<PlaylistFile>
 
+    internal abstract suspend fun migrate(migrations: Map<Music.UID, Music.UID>)
+
     companion object {
         fun from(context: Context): StoredPlaylists =
             StoredPlaylistsImpl(PlaylistDatabase.from(context).playlistDao())
@@ -51,4 +53,10 @@ private class StoredPlaylistsImpl(private val playlistDao: PlaylistDao) : Stored
                 StoredPlaylistHandle(it.playlistInfo, playlistDao),
             )
         }
+
+    override suspend fun migrate(migrations: Map<Music.UID, Music.UID>) {
+        for ((oldUid, newUid) in migrations) {
+            playlistDao.migrateSongUid(oldUid, newUid)
+        }
+    }
 }

--- a/musikr/src/main/java/org/oxycblt/musikr/playlist/db/StoredPlaylists.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/playlist/db/StoredPlaylists.kt
@@ -32,6 +32,20 @@ abstract class StoredPlaylists {
 
     internal abstract suspend fun migrate(migrations: Map<Music.UID, Music.UID>)
 
+    /**
+     * Compare [currentUriToUid] (uri → canonical UID for every song in the current index run)
+     * against the stored URI index and return a map of old UID → new UID for every song whose UID
+     * has changed since the last run.
+     */
+    internal abstract suspend fun computeUriMigrations(
+        currentUriToUid: Map<String, Music.UID>
+    ): Map<Music.UID, Music.UID>
+
+    /**
+     * Persist [uriToUid] as the new URI index, replacing whatever was stored from the previous run.
+     */
+    internal abstract suspend fun updateUriIndex(uriToUid: Map<String, Music.UID>)
+
     companion object {
         fun from(context: Context): StoredPlaylists =
             StoredPlaylistsImpl(PlaylistDatabase.from(context).playlistDao())
@@ -58,5 +72,22 @@ private class StoredPlaylistsImpl(private val playlistDao: PlaylistDao) : Stored
         for ((oldUid, newUid) in migrations) {
             playlistDao.migrateSongUid(oldUid, newUid)
         }
+    }
+
+    override suspend fun computeUriMigrations(
+        currentUriToUid: Map<String, Music.UID>
+    ): Map<Music.UID, Music.UID> {
+        val migrations = mutableMapOf<Music.UID, Music.UID>()
+        for (record in playlistDao.readUriRecords()) {
+            val newUid = currentUriToUid[record.uri] ?: continue
+            if (newUid != record.songUid) {
+                migrations[record.songUid] = newUid
+            }
+        }
+        return migrations
+    }
+
+    override suspend fun updateUriIndex(uriToUid: Map<String, Music.UID>) {
+        playlistDao.replaceUriIndex(uriToUid.map { (uri, uid) -> SongUriRecord(uri, uid) })
     }
 }

--- a/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/PreMusic.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/PreMusic.kt
@@ -35,6 +35,9 @@ internal data class PreSong(
     val v363Uid: Music.UID,
     val v400Uid: Music.UID,
     val v401Uid: Music.UID,
+    /** Hash-based UIDs this song carried before a MusicBrainz ID superseded them. Empty when no
+     * MusicBrainz ID is present (the v3xx UIDs already are the hash UIDs). */
+    val legacyUids: List<Music.UID>,
     val musicBrainzId: UUID?,
     val name: Name.Known,
     val rawName: String,

--- a/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/PreMusic.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/PreMusic.kt
@@ -35,8 +35,10 @@ internal data class PreSong(
     val v363Uid: Music.UID,
     val v400Uid: Music.UID,
     val v401Uid: Music.UID,
-    /** Hash-based UIDs this song carried before a MusicBrainz ID superseded them. Empty when no
-     * MusicBrainz ID is present (the v3xx UIDs already are the hash UIDs). */
+    /**
+     * Hash-based UIDs this song carried before a MusicBrainz ID superseded them. Empty when no
+     * MusicBrainz ID is present (the v3xx UIDs already are the hash UIDs).
+     */
     val legacyUids: List<Music.UID>,
     val musicBrainzId: UUID?,
     val name: Name.Known,

--- a/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/TagInterpreter.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/TagInterpreter.kt
@@ -79,57 +79,69 @@ private class TagInterpreterImpl(private val interpretation: Interpretation) : T
         val albumNameOrDir = song.tags.albumName ?: song.file.path.directory.name
 
         val musicBrainzId = song.tags.musicBrainzId?.toUuidOrNull()
-        val v363uid =
-            musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) }
-                ?: Music.UID.auxio(Music.UID.Item.SONG) {
-                    update(songNameOrFileWithoutExtCorrect)
-                    update(albumNameOrDir)
-                    update(song.tags.date)
 
-                    update(song.tags.track)
-                    update(song.tags.disc)
+        // Always compute hash-based UIDs. They become the canonical UIDs when no MusicBrainz ID
+        // is present, and become legacyUids (for playlist migration) when one is present.
+        val v363hash =
+            Music.UID.auxio(Music.UID.Item.SONG) {
+                update(songNameOrFileWithoutExtCorrect)
+                update(albumNameOrDir)
+                update(song.tags.date)
 
-                    update(song.tags.artistNames)
-                    update(song.tags.albumArtistNames)
-                }
+                update(song.tags.track)
+                update(song.tags.disc)
+
+                update(song.tags.artistNames)
+                update(song.tags.albumArtistNames)
+            }
 
         // I was an idiot and accidentally changed the UID spec in v4.0.0, so we need to calculate
         // the broken UID too and maintain compat for that version.
-        val v400uid =
-            musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) }
-                ?: Music.UID.auxio(Music.UID.Item.SONG) {
-                    update(songNameOrFile)
-                    update(song.tags.albumName)
-                    update(song.tags.date)
+        val v400hash =
+            Music.UID.auxio(Music.UID.Item.SONG) {
+                update(songNameOrFile)
+                update(song.tags.albumName)
+                update(song.tags.date)
 
-                    update(song.tags.track)
-                    update(song.tags.disc)
+                update(song.tags.track)
+                update(song.tags.disc)
 
-                    val artistNames = interpretation.separators.split(song.tags.artistNames)
-                    update(artistNames.ifEmpty { listOf(null) })
-                    val albumArtistNames =
-                        interpretation.separators.split(song.tags.albumArtistNames)
-                    update(albumArtistNames.ifEmpty { artistNames }.ifEmpty { listOf(null) })
-                }
+                val artistNames = interpretation.separators.split(song.tags.artistNames)
+                update(artistNames.ifEmpty { listOf(null) })
+                val albumArtistNames =
+                    interpretation.separators.split(song.tags.albumArtistNames)
+                update(albumArtistNames.ifEmpty { artistNames }.ifEmpty { listOf(null) })
+            }
 
-        val v401uid =
-            musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) }
-                ?: Music.UID.auxio(Music.UID.Item.SONG) {
-                    update(songNameOrFileWithoutExt)
-                    update(albumNameOrDir)
-                    update(song.tags.date)
+        val v401hash =
+            Music.UID.auxio(Music.UID.Item.SONG) {
+                update(songNameOrFileWithoutExt)
+                update(albumNameOrDir)
+                update(song.tags.date)
 
-                    update(song.tags.track)
-                    update(song.tags.disc)
+                update(song.tags.track)
+                update(song.tags.disc)
 
-                    update(song.tags.artistNames)
-                    update(song.tags.albumArtistNames)
-                }
+                update(song.tags.artistNames)
+                update(song.tags.albumArtistNames)
+            }
+
+        val v363uid = musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v363hash
+        val v400uid = musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v400hash
+        val v401uid = musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v401hash
+
+        // Collect the hash UIDs as legacy only when a MusicBrainz ID supersedes them. These are
+        // used during playlist resolution to match playlist entries that were stored under the old
+        // hash UID, and to migrate the DB to the new UID so future runs don't need them.
+        val legacyUids =
+            if (musicBrainzId != null) listOf(v363hash, v400hash, v401hash).distinct()
+            else emptyList()
 
         return PreSong(
             v363Uid = v363uid,
             v400Uid = v400uid,
             v401Uid = v401uid,
+            legacyUids = legacyUids,
             uri = uri,
             path = song.file.path,
             size = song.file.size,

--- a/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/TagInterpreter.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/TagInterpreter.kt
@@ -79,9 +79,11 @@ private class TagInterpreterImpl(private val interpretation: Interpretation) : T
         val albumNameOrDir = song.tags.albumName ?: song.file.path.directory.name
 
         val musicBrainzId = song.tags.musicBrainzId?.toUuidOrNull()
+        val musicBrainzRecordingId = song.tags.musicBrainzRecordingId?.toUuidOrNull()
+        val acoustidFingerprint = song.tags.acoustidFingerprint
 
-        // Always compute hash-based UIDs. They become the canonical UIDs when no MusicBrainz ID
-        // is present, and become legacyUids (for playlist migration) when one is present.
+        // Always compute hash-based UIDs. They become the canonical UIDs when no stable ID is
+        // present, and become legacyUids (for playlist migration) when one is present.
         val v363hash =
             Music.UID.auxio(Music.UID.Item.SONG) {
                 update(songNameOrFileWithoutExtCorrect)
@@ -125,19 +127,45 @@ private class TagInterpreterImpl(private val interpretation: Interpretation) : T
                 update(song.tags.albumArtistNames)
             }
 
-        val v363uid =
-            musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v363hash
-        val v400uid =
-            musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v400hash
-        val v401uid =
-            musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v401hash
+        // Select the canonical UID by priority: AcoustID (content-based, most stable) >
+        // MusicBrainz recording ID (recording-specific) >
+        // MusicBrainz release track ID (release-specific) >
+        // hash (tag-based, falls back to URI tracking for drift).
+        val stableUid =
+            when {
+                acoustidFingerprint != null ->
+                    Music.UID.acoustid(Music.UID.Item.SONG, acoustidFingerprint)
+                musicBrainzRecordingId != null ->
+                    Music.UID.musicBrainz(Music.UID.Item.SONG, musicBrainzRecordingId)
+                musicBrainzId != null -> Music.UID.musicBrainz(Music.UID.Item.SONG, musicBrainzId)
+                else -> null
+            }
 
-        // Collect the hash UIDs as legacy only when a MusicBrainz ID supersedes them. These are
-        // used during playlist resolution to match playlist entries that were stored under the old
-        // hash UID, and to migrate the DB to the new UID so future runs don't need them.
+        val v363uid = stableUid ?: v363hash
+        val v400uid = stableUid ?: v400hash
+        val v401uid = stableUid ?: v401hash
+
+        // All lower-priority UIDs the song may have been stored under in playlists. These are
+        // used during resolution to match and migrate playlist entries stored under any older UID.
         val legacyUids =
-            if (musicBrainzId != null) listOf(v363hash, v400hash, v401hash).distinct()
-            else emptyList()
+            if (stableUid != null) {
+                buildList {
+                        if (acoustidFingerprint != null) {
+                            musicBrainzRecordingId?.let {
+                                add(Music.UID.musicBrainz(Music.UID.Item.SONG, it))
+                            }
+                            musicBrainzId?.let {
+                                add(Music.UID.musicBrainz(Music.UID.Item.SONG, it))
+                            }
+                        } else if (musicBrainzRecordingId != null) {
+                            musicBrainzId?.let {
+                                add(Music.UID.musicBrainz(Music.UID.Item.SONG, it))
+                            }
+                        }
+                        addAll(listOf(v363hash, v400hash, v401hash))
+                    }
+                    .distinct()
+            } else emptyList()
 
         return PreSong(
             v363Uid = v363uid,

--- a/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/TagInterpreter.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/interpret/TagInterpreter.kt
@@ -108,8 +108,7 @@ private class TagInterpreterImpl(private val interpretation: Interpretation) : T
 
                 val artistNames = interpretation.separators.split(song.tags.artistNames)
                 update(artistNames.ifEmpty { listOf(null) })
-                val albumArtistNames =
-                    interpretation.separators.split(song.tags.albumArtistNames)
+                val albumArtistNames = interpretation.separators.split(song.tags.albumArtistNames)
                 update(albumArtistNames.ifEmpty { artistNames }.ifEmpty { listOf(null) })
             }
 
@@ -126,9 +125,12 @@ private class TagInterpreterImpl(private val interpretation: Interpretation) : T
                 update(song.tags.albumArtistNames)
             }
 
-        val v363uid = musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v363hash
-        val v400uid = musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v400hash
-        val v401uid = musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v401hash
+        val v363uid =
+            musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v363hash
+        val v400uid =
+            musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v400hash
+        val v401uid =
+            musicBrainzId?.let { Music.UID.musicBrainz(Music.UID.Item.SONG, it) } ?: v401hash
 
         // Collect the hash UIDs as legacy only when a MusicBrainz ID supersedes them. These are
         // used during playlist resolution to match playlist entries that were stored under the old

--- a/musikr/src/main/java/org/oxycblt/musikr/tag/parse/ParsedTags.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/parse/ParsedTags.kt
@@ -25,6 +25,8 @@ data class ParsedTags(
     val replayGainTrackAdjustment: Float? = null,
     val replayGainAlbumAdjustment: Float? = null,
     val musicBrainzId: String? = null,
+    val musicBrainzRecordingId: String? = null,
+    val acoustidFingerprint: String? = null,
     val name: String? = null,
     val sortName: String? = null,
     val track: Int? = null,

--- a/musikr/src/main/java/org/oxycblt/musikr/tag/parse/TagFields.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/parse/TagFields.kt
@@ -39,6 +39,21 @@ internal fun Metadata.musicBrainzId() =
             ?: id3v2["TXXX:MUSICBRAINZ_RELEASETRACKID"])
         ?.first()
 
+internal fun Metadata.musicBrainzRecordingId() =
+    (xiph["MUSICBRAINZ_TRACKID"]
+            ?: xiph["MUSICBRAINZ TRACK ID"]
+            ?: mp4["----:COM.APPLE.ITUNES:MUSICBRAINZ TRACK ID"]
+            ?: mp4["----:COM.APPLE.ITUNES:MUSICBRAINZ_TRACKID"]
+            ?: id3v2["TXXX:MUSICBRAINZ TRACK ID"]
+            ?: id3v2["TXXX:MUSICBRAINZ_TRACKID"])
+        ?.first()
+
+internal fun Metadata.acoustidFingerprint() =
+    (xiph["ACOUSTID_FINGERPRINT"]
+            ?: mp4["----:COM.APPLE.ITUNES:ACOUSTID_FINGERPRINT"]
+            ?: id3v2["TXXX:ACOUSTID_FINGERPRINT"])
+        ?.first()
+
 internal fun Metadata.name() =
     (xiph["TITLE"] ?: mp4["©nam"] ?: mp4["©trk"] ?: id3v2["TIT2"])?.first()
 

--- a/musikr/src/main/java/org/oxycblt/musikr/tag/parse/TagParser.kt
+++ b/musikr/src/main/java/org/oxycblt/musikr/tag/parse/TagParser.kt
@@ -40,6 +40,8 @@ private data object TagParserImpl : TagParser {
             replayGainTrackAdjustment = metadata.replayGainTrackAdjustment(),
             replayGainAlbumAdjustment = metadata.replayGainAlbumAdjustment(),
             musicBrainzId = metadata.musicBrainzId(),
+            musicBrainzRecordingId = metadata.musicBrainzRecordingId(),
+            acoustidFingerprint = metadata.acoustidFingerprint(),
             name = metadata.name(),
             sortName = metadata.sortName(),
             track = metadata.track(),


### PR DESCRIPTION
<!-- Please fill out all this information. -->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
Songs in playlists could silently disappear whenever their UID changed — either because a MusicBrainz ID was added to a previously hash-identified song, or because tag edits produced a different hash. This PR fixes that end-to-end.

- Add a priority-based UID hierarchy for songs: `ACOUSTID_FINGERPRINT` (content-based, most stable) > `MUSICBRAINZ_TRACKID` (recording ID) > `MUSICBRAINZ_RELEASETRACKID` (release track ID, previous behaviour) > hash of tag metadata
- Add `Music.UID.Format.ACOUSTID` and `Music.UID.acoustid()` factory; update `fromString()` to parse the new format
- Add `TagFields.musicBrainzRecordingId()` and `TagFields.acoustidFingerprint()` tag accessors across Xiph/MP4/ID3v2
- Add `PreSong.legacyUids`: all lower-priority UIDs a song carried before a stable identifier superseded them. During `MusicGraph.build()`, each song probes playlist pointer maps with its legacy UIDs and records any matches in `uidMigrations`, which are written to the DB after indexing
- Add `SongUriRecord` (DB version 30→31, non-destructive migration): a persistent `fileUri → songUid` index updated after every rescan. `computeUriMigrations` diffs the stored mapping against the current one to catch any UID change the `legacyUids` probe cannot — specifically when the tags that make up the hash are also edited, or when a unique identifier like a MusicBrainz ID is gained at the same time other tags change
- Add `MusicGraph.applyMigrations()`: patches playlist vertices in-memory after URI migrations are computed so corrected playlist contents are visible in the same rescan rather than requiring a second one

#### Fixes the following issues
Songs added to a playlist disappear after retagging — whether that is editing metadata fields, adding a MusicBrainz ID, or both at once. Also https://github.com/OxygenCobalt/Auxio/issues/1004. 

#### Any additional information
The two migration mechanisms are complementary:

The `legacyUids` probe works purely from tag data computed at index time. It handles the clean case of a song gaining a stable identifier (MusicBrainz/AcoustID) without other tag changes, and requires no DB read beyond the playlist itself.

The URI index is the fallback for everything else. Because it tracks the last-known UID per file path across rescans, it can detect any UID change regardless of cause — hash drift from tag edits, gaining a stable ID alongside other edits, or any future UID format change. Both sources are merged before being applied.

#### APK testing
[debug.zip](https://github.com/user-attachments/files/26516265/debug.zip)

#### Due diligence
- [x] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [x] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.