### PR TITLE
Add missing instruction to add proguard-rules.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ pkg -S android-studio
     ```
     Additionally: Set java version to jdk21-openjdk
 
+- Create an empty file at media/libraries/common_ktx/proguard-rules.txt
+
 - Run ./gradlew assembleDebug
 
 #### Connecting to your Android Device


### PR DESCRIPTION
#### What is it?
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
Can't build without proguard-rules.txt at least on MacOS