### PR TITLE
fix media notification

### DIFF
--- a/app/src/main/java/org/oxycblt/auxio/image/BitmapProvider.kt
+++ b/app/src/main/java/org/oxycblt/auxio/image/BitmapProvider.kt
@@ -95,8 +95,13 @@ constructor(
                 .onConfigRequest(
                     ImageRequest.Builder(context)
                         .data(song.cover)
-                        // Use ORIGINAL sizing, as we are not loading into any View-like component.
-                        .size(Size.ORIGINAL)
+                        // dot166: No longer using Size.ORIGINAL because on Android 17
+                        // (Cinnamon Bun) Size.ORIGINAL causes issues #1380 and #1382
+                        // set to 512x512 as it was larger artwork that broke the notification,
+                        // tested with ワールズエンド・ダンスホール (World's End Dancehall) by wowaka
+                        // this patch does not affect widgets, as widgets already force ORIGINAL
+                        // anyway
+                        .size(Size(width = 512, height = 512))
                 )
                 .target(
                     onSuccess = {

--- a/app/src/main/java/org/oxycblt/auxio/image/BitmapProvider.kt
+++ b/app/src/main/java/org/oxycblt/auxio/image/BitmapProvider.kt
@@ -97,11 +97,12 @@ constructor(
                         .data(song.cover)
                         // dot166: No longer using Size.ORIGINAL because on Android 17
                         // (Cinnamon Bun) Size.ORIGINAL causes issues #1380 and #1382
-                        // set to 512x512 as it was larger artwork that broke the notification,
+                        // set to 640x640 as it was larger artwork that broke the notification,
                         // tested with ワールズエンド・ダンスホール (World's End Dancehall) by wowaka
                         // this patch does not affect widgets, as widgets already force ORIGINAL
-                        // anyway
-                        .size(Size(width = 512, height = 512))
+                        // anyway, was originally 512x512, but @programmerlexi suggested it be
+                        // 640x640 as that is the most common resolution (according to them)
+                        .size(Size(width = 640, height = 640))
                 )
                 .target(
                     onSuccess = {


### PR DESCRIPTION
<!-- Please fill out all this information. -->

#### What is it?
- [x] Bugfix (user facing)
- [ ] Feature (user facing)
- [ ] Codebase improvement (dev facing)
- [ ] Meta improvement to the project (dev facing)

#### Description of changes
<!-- Bullet points or free-form text -->
- fixes issues https://github.com/OxygenCobalt/Auxio/issues/1380 and https://github.com/OxygenCobalt/Auxio/issues/1382 by replacing Size.ORIGINAL call with Size(width = 640, height = 640) (originally Size(width = 512, height = 512), before suggested changes)

#### Fixes the following issues
<!-- Also add any other links relevant to your change. -->
https://github.com/OxygenCobalt/Auxio/issues/1380 and https://github.com/OxygenCobalt/Auxio/issues/1382

#### Any additional information
<!-- Also add any information relevant to this PR. -->
(copied from changed comment), No longer using Size.ORIGINAL because on Android 17 (Cinnamon Bun) Size.ORIGINAL causes issues #1380 and #1382, set to 640x640 as it was larger artwork that broke the notification, tested with ワールズエンド・ダンスホール (World's End Dancehall) by wowaka, this patch does not affect widgets, as widgets already force ORIGINAL anyway, was originally 512x512, but @programmerlexi suggested it be 640x640 as that is the most common resolution (according to them)

#### APK testing
<!-- Please create a debug APK for your changes, if possible. -->
[app-debug.zip](https://github.com/user-attachments/files/30203978/app-debug.zip)



#### Due diligence
- [x] I have read the [Contribution Guidelines](https://github.com/OxygenCobalt/Auxio/blob/dev/.github/CONTRIBUTING.md).
- [x] I have read the [Why Are These Features Missing?](https://github.com/OxygenCobalt/Auxio/wiki/Why-Are-These-Features-Missing%3F) page.