### PR TITLE
feat: Fast-forward/rewind within a track

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -179,4 +179,6 @@ dependencies {
 
     // Fuzzy search
     implementation 'org.apache.commons:commons-text:1.15.0'
+
+    testImplementation "junit:junit:4.13.2"
 }

--- a/app/src/main/java/org/oxycblt/auxio/playback/PlaybackPanelFragment.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/PlaybackPanelFragment.kt
@@ -24,9 +24,12 @@ import android.content.Intent
 import android.media.audiofx.AudioEffect
 import android.os.Build
 import android.os.Bundle
+import android.view.HapticFeedbackConstants
 import android.view.LayoutInflater
 import android.view.MenuItem
+import android.view.MotionEvent
 import android.view.View
+import android.view.ViewConfiguration
 import androidx.activity.result.ActivityResultLauncher
 import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.widget.Toolbar
@@ -44,6 +47,7 @@ import org.oxycblt.auxio.music.resolve
 import org.oxycblt.auxio.music.resolveNames
 import org.oxycblt.auxio.playback.queue.QueueViewModel
 import org.oxycblt.auxio.playback.state.RepeatMode
+import org.oxycblt.auxio.playback.state.ScanDirection
 import org.oxycblt.auxio.playback.ui.StyledSeekBar
 import org.oxycblt.auxio.playback.ui.stepper.Direction
 import org.oxycblt.auxio.playback.ui.stepper.StepperOverlay
@@ -153,7 +157,8 @@ class PlaybackPanelFragment :
         // Set up actions
         // TODO: Add better playback button accessibility
         binding.playbackRepeat.setOnClickListener { playbackModel.toggleRepeatMode() }
-        binding.playbackSkipPrev.setOnClickListener { playbackModel.prev() }
+        binding.playbackSkipPrev.setupScanAction(ScanDirection.BACKWARD, playbackModel::prev)
+
         binding.playbackPlayPause.apply {
             @SuppressLint("RestrictedApi")
             setCornerSpringForce(
@@ -164,7 +169,7 @@ class PlaybackPanelFragment :
             )
             setOnClickListener { playbackModel.togglePlaying() }
         }
-        binding.playbackSkipNext.setOnClickListener { playbackModel.next() }
+        binding.playbackSkipNext.setupScanAction(ScanDirection.FORWARD, playbackModel::next)
         binding.playbackShuffle.setOnClickListener { playbackModel.toggleShuffled() }
         binding.playbackMore?.setOnClickListener {
             playbackModel.song.value?.let {
@@ -218,6 +223,7 @@ class PlaybackPanelFragment :
     //    }
 
     override fun onDestroyBinding(binding: FragmentPlaybackPanelBinding) {
+        playbackModel.stopScan()
         equalizerLauncher = null
         binding.playbackRepeat.clearPendingIcon()
         binding.playbackSong.isSelected = false
@@ -226,6 +232,75 @@ class PlaybackPanelFragment :
         binding.playbackToolbar.setOnMenuItemClickListener(null)
         userAwarePagerCallback?.release()
         binding.playbackPager?.adapter = null
+    }
+
+    private fun View.setupScanAction(direction: ScanDirection, click: () -> Unit) {
+        var scanning = false
+        var cancelled = false
+        val touchSlop = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
+        val beginScan = Runnable {
+            scanning = true
+            performHapticFeedback(HapticFeedbackConstants.LONG_PRESS)
+            playbackModel.startScan(direction)
+        }
+
+        setOnClickListener { click() }
+        setOnTouchListener { view, event ->
+            when (event.actionMasked) {
+                MotionEvent.ACTION_DOWN -> {
+                    scanning = false
+                    cancelled = false
+                    view.isPressed = true
+                    view.postDelayed(beginScan, ViewConfiguration.getLongPressTimeout().toLong())
+                }
+                MotionEvent.ACTION_MOVE -> {
+                    if (
+                        event.x !in -touchSlop..view.width + touchSlop ||
+                            event.y !in -touchSlop..view.height + touchSlop
+                    ) {
+                        view.removeCallbacks(beginScan)
+                        if (scanning) {
+                            playbackModel.stopScan()
+                            scanning = false
+                        }
+                        cancelled = true
+                        view.isPressed = false
+                    }
+                }
+                MotionEvent.ACTION_UP -> {
+                    view.removeCallbacks(beginScan)
+                    view.isPressed = false
+                    if (scanning) {
+                        playbackModel.stopScan()
+                        scanning = false
+                    } else if (!cancelled) {
+                        view.performClick()
+                    }
+                }
+                MotionEvent.ACTION_CANCEL -> {
+                    view.removeCallbacks(beginScan)
+                    view.isPressed = false
+                    if (scanning) {
+                        playbackModel.stopScan()
+                        scanning = false
+                    }
+                }
+            }
+            true
+        }
+        addOnAttachStateChangeListener(
+            object : View.OnAttachStateChangeListener {
+                override fun onViewAttachedToWindow(view: View) = Unit
+
+                override fun onViewDetachedFromWindow(view: View) {
+                    view.removeCallbacks(beginScan)
+                    if (scanning) {
+                        playbackModel.stopScan()
+                        scanning = false
+                    }
+                }
+            }
+        )
     }
 
     override fun onMenuItemClick(item: MenuItem): Boolean {

--- a/app/src/main/java/org/oxycblt/auxio/playback/PlaybackViewModel.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/PlaybackViewModel.kt
@@ -35,6 +35,7 @@ import org.oxycblt.auxio.playback.state.PlaybackStateManager
 import org.oxycblt.auxio.playback.state.Progression
 import org.oxycblt.auxio.playback.state.QueueChange
 import org.oxycblt.auxio.playback.state.RepeatMode
+import org.oxycblt.auxio.playback.state.ScanDirection
 import org.oxycblt.auxio.playback.state.ShuffleMode
 import org.oxycblt.auxio.util.Event
 import org.oxycblt.auxio.util.MutableEvent
@@ -473,6 +474,18 @@ constructor(
                 (currentPositionMs + STEP_INCREMENT).coerceAtMost(currentSong.durationMs)
             playbackManager.seekTo(newPositionMs)
         }
+    }
+
+    /** Begin scanning through the current track while a transport button is held. */
+    fun startScan(direction: ScanDirection) {
+        L.d("Starting scan in direction $direction")
+        playbackManager.startScan(direction)
+    }
+
+    /** Stop scanning and return to normal playback. */
+    fun stopScan() {
+        L.d("Stopping scan")
+        playbackManager.stopScan()
     }
 
     // --- QUEUE FUNCTIONS ---

--- a/app/src/main/java/org/oxycblt/auxio/playback/replaygain/ReplayGainAudioProcessor.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/replaygain/ReplayGainAudioProcessor.kt
@@ -50,12 +50,17 @@ constructor(
     private val playbackManager: PlaybackStateManager,
     private val playbackSettings: PlaybackSettings,
 ) : BaseAudioProcessor(), PlaybackStateManager.Listener, PlaybackSettings.Listener {
+    @Volatile
     private var volume = 1f
         set(value) {
             field = value
             // Processed bytes are no longer valid, flush the stream
             flush()
         }
+
+    /** The current linear ReplayGain amplification. */
+    val amplification: Float
+        get() = volume
 
     fun attach() {
         playbackManager.addListener(this)

--- a/app/src/main/java/org/oxycblt/auxio/playback/service/ExoPlaybackStateHolder.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/service/ExoPlaybackStateHolder.kt
@@ -59,6 +59,7 @@ import org.oxycblt.auxio.playback.state.PlaybackStateManager
 import org.oxycblt.auxio.playback.state.Progression
 import org.oxycblt.auxio.playback.state.RawQueue
 import org.oxycblt.auxio.playback.state.RepeatMode
+import org.oxycblt.auxio.playback.state.ScanDirection
 import org.oxycblt.auxio.playback.state.ShuffleMode
 import org.oxycblt.auxio.playback.state.StateAck
 import org.oxycblt.musikr.MusicParent
@@ -76,12 +77,22 @@ class ExoPlaybackStateHolder(
     private val replayGainProcessor: ReplayGainAudioProcessor,
     private val musicRepository: MusicRepository,
     private val imageSettings: ImageSettings,
+    private val reverseAudioEngineFactory: ReverseAudioEngine.Factory,
 ) :
     PlaybackStateHolder,
     Player.Listener,
     MusicRepository.UpdateListener,
     PlaybackSettings.Listener,
     ImageSettings.Listener {
+    private data class ScanState(
+        val direction: ScanDirection,
+        val wasPlaying: Boolean,
+        val pauseAtEndOfMediaItems: Boolean,
+    )
+
+    private var scanState: ScanState? = null
+    private var reverseEngine: ReverseAudioEngine? = null
+
     private val saveJob = Job()
     private val saveScope = CoroutineScope(Dispatchers.IO + saveJob)
     private val restoreScope = CoroutineScope(Dispatchers.IO + saveJob)
@@ -101,6 +112,8 @@ class ExoPlaybackStateHolder(
     }
 
     fun release() {
+        stopScan(false)
+        closeAudioEffectControlSession()
         saveJob.cancel()
         playbackManager.unregisterStateHolder(this)
         musicRepository.removeUpdateListener(this)
@@ -117,9 +130,26 @@ class ExoPlaybackStateHolder(
     override val progression: Progression
         get() {
             val mediaItem = player.currentMediaItem ?: return Progression.nil()
-            val duration = mediaItem.mediaMetadata.extras?.getLong("durationMs") ?: Long.MAX_VALUE
-            val clampedPosition = player.currentPosition.coerceAtLeast(0).coerceAtMost(duration)
-            return Progression.from(player.playWhenReady, player.isPlaying, clampedPosition)
+            val durationMs = mediaItem.song?.durationMs ?: Long.MAX_VALUE
+            val reverseEngine = reverseEngine
+            if (reverseEngine != null) {
+                return Progression.from(
+                    isPlaying = true,
+                    isAdvancing = reverseEngine.isPlaying,
+                    positionMs = reverseEngine.currentPositionMs,
+                    rate = ScanDirection.BACKWARD.rate,
+                    durationMs = durationMs,
+                )
+            }
+
+            val scanState = scanState
+            return Progression.from(
+                isPlaying = player.playWhenReady || scanState?.direction == ScanDirection.FORWARD,
+                isAdvancing = player.isPlaying,
+                positionMs = player.currentPosition.coerceIn(0, durationMs),
+                rate = player.playbackParameters.speed,
+                durationMs = durationMs,
+            )
         }
 
     override val repeatMode
@@ -233,6 +263,86 @@ class ExoPlaybackStateHolder(
         // Ack handled w/ExoPlayer events
     }
 
+    override fun startScan(direction: ScanDirection) {
+        if (scanState != null || player.currentMediaItem == null) {
+            return
+        }
+
+        val wasPlaying = player.playWhenReady
+        scanState = ScanState(direction, wasPlaying, player.pauseAtEndOfMediaItems)
+
+        when (direction) {
+            ScanDirection.FORWARD -> {
+                player.setPlaybackSpeed(direction.rate)
+                player.pauseAtEndOfMediaItems = true
+                player.play()
+                playbackManager.ack(this, StateAck.ProgressionChanged)
+            }
+
+            ScanDirection.BACKWARD -> {
+                val positionMs = player.currentPosition
+                if (positionMs <= 0) {
+                    scanState = null
+                    return
+                }
+
+                reverseEngine =
+                    reverseAudioEngineFactory.create(
+                        uri = requireNotNull(player.currentMediaItem?.localConfiguration?.uri),
+                        startPositionMs = positionMs,
+                        speed = -direction.rate,
+                        audioSessionId = player.audioSessionId,
+                        amplification = replayGainProcessor.amplification,
+                    )
+                player.pause()
+                openAudioEffectControlSession()
+                reverseEngine?.start(
+                    onPlaybackChanged = { playbackManager.ack(this, StateAck.ProgressionChanged) },
+                    onEnded = { stopScan() },
+                    onError = { error ->
+                        L.e(error, "Unable to play reverse audio")
+                        stopScan(error !is ReverseAudioFocusLostException)
+                    },
+                )
+
+                playbackManager.ack(this, StateAck.ProgressionChanged)
+            }
+        }
+    }
+
+    override fun stopScan() {
+        stopScan(true)
+    }
+
+    private fun stopScan(resumePlayback: Boolean) {
+        val activeScan = scanState ?: return
+        scanState = null
+
+        when (activeScan.direction) {
+            ScanDirection.FORWARD -> {
+                player.setPlaybackSpeed(1f)
+            }
+
+            ScanDirection.BACKWARD -> {
+                val activeReverseEngine = reverseEngine
+                reverseEngine = null
+
+                val positionMs = activeReverseEngine?.currentPositionMs ?: player.currentPosition
+                activeReverseEngine?.release()
+                player.seekTo(positionMs)
+            }
+        }
+
+        player.pauseAtEndOfMediaItems = activeScan.pauseAtEndOfMediaItems
+        player.setPlaybackSpeed(1f)
+        player.playWhenReady = resumePlayback && activeScan.wasPlaying
+        if (!player.playWhenReady) {
+            closeAudioEffectControlSession()
+        }
+        playbackManager.ack(this, StateAck.ProgressionChanged)
+        deferSave()
+    }
+
     override fun repeatMode(repeatMode: RepeatMode) {
         player.repeatMode =
             when (repeatMode) {
@@ -246,6 +356,8 @@ class ExoPlaybackStateHolder(
     }
 
     override fun newPlayback(command: PlaybackCommand) {
+        stopScan()
+
         parent = command.parent
         player.shuffleModeEnabled = command.shuffled
         player.setMediaItems(command.queue.map { it.buildMediaItem() })
@@ -405,6 +517,8 @@ class ExoPlaybackStateHolder(
         repeatMode: RepeatMode,
         ack: StateAck.NewPlayback?,
     ) {
+        stopScan()
+
         var sendNewPlaybackEvent = false
         var shouldSeek = false
         if (this.parent != parent) {
@@ -471,18 +585,9 @@ class ExoPlaybackStateHolder(
             // Mark that we have started playing so that the notification can now be posted.
             L.d("Player has started playing")
             sessionOngoing = true
-            if (!openAudioEffectSession) {
-                // Convention to start an audioeffect session on play/pause rather than
-                // start/stop
-                L.d("Opening audio effect session")
-                broadcastAudioEffectAction(AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION)
-                openAudioEffectSession = true
-            }
-        } else if (openAudioEffectSession) {
-            // Make sure to close the audio session when we stop playback.
-            L.d("Closing audio effect session")
-            broadcastAudioEffectAction(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION)
-            openAudioEffectSession = false
+            openAudioEffectControlSession()
+        } else if (reverseEngine == null) {
+            closeAudioEffectControlSession()
         }
     }
 
@@ -490,6 +595,13 @@ class ExoPlaybackStateHolder(
         super.onPlaybackStateChanged(playbackState)
 
         if (playbackState == Player.STATE_ENDED && player.repeatMode == Player.REPEAT_MODE_OFF) {
+            if (scanState?.direction == ScanDirection.FORWARD) {
+                player.pause()
+                val durationMs = player.currentMediaItem?.song?.durationMs ?: return
+                player.seekTo((durationMs - 1).coerceAtLeast(0))
+                playbackManager.ack(this, StateAck.ProgressionChanged)
+                return
+            }
             goto(0)
             player.pause()
         }
@@ -497,6 +609,7 @@ class ExoPlaybackStateHolder(
 
     override fun onMediaItemTransition(mediaItem: MediaItem?, reason: Int) {
         super.onMediaItemTransition(mediaItem, reason)
+        stopScan()
 
         if (reason == Player.MEDIA_ITEM_TRANSITION_REASON_AUTO) {
             playbackManager.ack(this, StateAck.IndexMoved)
@@ -522,6 +635,8 @@ class ExoPlaybackStateHolder(
     }
 
     override fun onPlayerError(error: PlaybackException) {
+        stopScan()
+
         // TODO: Replace with no skipping and a notification instead
         // If there's any issue, just go to the next song.
         L.e("Player error occurred")
@@ -538,6 +653,23 @@ class ExoPlaybackStateHolder(
                 .putExtra(AudioEffect.EXTRA_AUDIO_SESSION, audioSessionId)
                 .putExtra(AudioEffect.EXTRA_CONTENT_TYPE, AudioEffect.CONTENT_TYPE_MUSIC)
         )
+    }
+
+    private fun openAudioEffectControlSession() {
+        if (!openAudioEffectSession) {
+            // Convention to start an audioeffect session on play/pause rather than start/stop.
+            L.d("Opening audio effect session")
+            broadcastAudioEffectAction(AudioEffect.ACTION_OPEN_AUDIO_EFFECT_CONTROL_SESSION)
+            openAudioEffectSession = true
+        }
+    }
+
+    private fun closeAudioEffectControlSession() {
+        if (openAudioEffectSession) {
+            L.d("Closing audio effect session")
+            broadcastAudioEffectAction(AudioEffect.ACTION_CLOSE_AUDIO_EFFECT_CONTROL_SESSION)
+            openAudioEffectSession = false
+        }
     }
 
     // --- MUSICREPOSITORY METHODS ---
@@ -653,6 +785,7 @@ class ExoPlaybackStateHolder(
         private val replayGainProcessor: ReplayGainAudioProcessor,
         private val musicRepository: MusicRepository,
         private val imageSettings: ImageSettings,
+        private val reverseAudioEngineFactory: ReverseAudioEngine.Factory,
     ) {
         fun create(): ExoPlaybackStateHolder {
             // Since Auxio is a music player, only specify an audio renderer to save
@@ -697,6 +830,7 @@ class ExoPlaybackStateHolder(
                 replayGainProcessor,
                 musicRepository,
                 imageSettings,
+                reverseAudioEngineFactory,
             )
         }
     }

--- a/app/src/main/java/org/oxycblt/auxio/playback/service/ReverseAudioEngine.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/service/ReverseAudioEngine.kt
@@ -1,0 +1,668 @@
+/*
+ * Copyright (c) 2026 Auxio Project
+ * ReverseAudioEngine.kt is part of Auxio.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.oxycblt.auxio.playback.service
+
+import android.content.Context
+import android.media.AudioAttributes
+import android.media.AudioFocusRequest
+import android.media.AudioFormat
+import android.media.AudioManager
+import android.media.AudioTrack
+import android.media.MediaCodec
+import android.media.MediaExtractor
+import android.media.MediaFormat
+import android.net.Uri
+import android.os.Build
+import android.os.Handler
+import android.os.Looper
+import dagger.hilt.android.qualifiers.ApplicationContext
+import java.io.ByteArrayOutputStream
+import java.nio.ByteBuffer
+import java.util.concurrent.ArrayBlockingQueue
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
+import javax.inject.Inject
+import kotlin.math.max
+
+interface ReverseAudioEngine {
+    val currentPositionMs: Long
+    val isPlaying: Boolean
+
+    fun start(onPlaybackChanged: () -> Unit, onEnded: () -> Unit, onError: (Throwable) -> Unit)
+
+    fun release()
+
+    class Factory @Inject constructor(@ApplicationContext private val context: Context) {
+        fun create(
+            uri: Uri,
+            startPositionMs: Long,
+            speed: Float,
+            audioSessionId: Int,
+            amplification: Float,
+        ): ReverseAudioEngine =
+            PlatformReverseAudioEngine(
+                context,
+                uri,
+                startPositionMs.coerceIn(0, Long.MAX_VALUE / 1000) * 1000,
+                speed,
+                audioSessionId,
+                amplification,
+            )
+    }
+}
+
+private class PlatformReverseAudioEngine(
+    private val context: Context,
+    private val uri: Uri,
+    private val startPositionUs: Long,
+    private val speed: Float,
+    private val audioSessionId: Int,
+    private val amplification: Float,
+) : ReverseAudioEngine {
+    private val started = AtomicBoolean()
+    private val released = AtomicBoolean()
+    private val stopped = AtomicBoolean()
+    private val callbackSent = AtomicBoolean()
+    private val mainHandler = Handler(Looper.getMainLooper())
+    private val audioManager = context.getSystemService(AudioManager::class.java)
+    private val audioFocusListener =
+        AudioManager.OnAudioFocusChangeListener { change ->
+            when (change) {
+                AudioManager.AUDIOFOCUS_GAIN -> {
+                    focusSuspended = false
+                    if (!stopped.get()) {
+                        audioTrack?.play()
+                        isPlaying = audioTrack != null
+                    }
+                    postPlaybackChanged()
+                }
+                AudioManager.AUDIOFOCUS_LOSS_TRANSIENT,
+                AudioManager.AUDIOFOCUS_LOSS_TRANSIENT_CAN_DUCK -> {
+                    finalPositionUs = currentPositionMs * 1000
+                    focusSuspended = true
+                    audioTrack?.pause()
+                    isPlaying = false
+                    postPlaybackChanged()
+                }
+                AudioManager.AUDIOFOCUS_LOSS -> {
+                    finalPositionUs = currentPositionMs * 1000
+                    focusSuspended = true
+                    audioTrack?.pause()
+                    isPlaying = false
+                    stopped.set(true)
+                    hasAudioFocus = false
+                    errorCallback?.let { postError(it, ReverseAudioFocusLostException()) }
+                }
+            }
+        }
+    private val windows = ArrayBlockingQueue<QueueItem>(WINDOW_QUEUE_SIZE)
+    private val executor =
+        Executors.newFixedThreadPool(2) { runnable ->
+            Thread(runnable, "Auxio reverse audio").apply { isDaemon = true }
+        }
+
+    @Volatile private var audioTrack: AudioTrack? = null
+    @Volatile private var playbackChangedCallback: (() -> Unit)? = null
+    @Volatile private var errorCallback: ((Throwable) -> Unit)? = null
+    @Volatile private var audioFocusRequest: AudioFocusRequest? = null
+    @Volatile private var hasAudioFocus = false
+    @Volatile private var focusSuspended = false
+    @Volatile private var sampleRate = 0
+    @Volatile private var finalPositionUs = startPositionUs
+    @Volatile
+    override var isPlaying = false
+        private set
+
+    override val currentPositionMs: Long
+        get() {
+            val track = audioTrack
+            val rate = sampleRate
+            if (track != null && rate > 0) {
+                val playedFrames = track.playbackHeadPosition.toLong() and UINT_MASK
+                finalPositionUs =
+                    (startPositionUs - playedFrames * MICROS_PER_SECOND / rate).coerceAtLeast(0)
+            }
+            return finalPositionUs / 1000
+        }
+
+    override fun start(
+        onPlaybackChanged: () -> Unit,
+        onEnded: () -> Unit,
+        onError: (Throwable) -> Unit,
+    ) {
+        if (!started.compareAndSet(false, true)) {
+            return
+        }
+        if (released.get()) {
+            postError(onError, IllegalStateException("Reverse audio engine was released"))
+            return
+        }
+        if (!speed.isFinite() || speed <= 0) {
+            stopped.set(true)
+            postError(onError, IllegalArgumentException("Playback speed must be positive"))
+            return
+        }
+        if (startPositionUs == 0L) {
+            finalPositionUs = 0
+            stopped.set(true)
+            postEnded(onEnded)
+            return
+        }
+        playbackChangedCallback = onPlaybackChanged
+        errorCallback = onError
+        if (!requestAudioFocus()) {
+            stopped.set(true)
+            postError(onError, IllegalStateException("Could not obtain audio focus"))
+            return
+        }
+
+        executor.execute { decodeWindows() }
+        executor.execute { playWindows(onEnded, onError) }
+    }
+
+    override fun release() {
+        if (!released.compareAndSet(false, true)) {
+            return
+        }
+        stopped.set(true)
+        finalPositionUs = currentPositionMs * 1000
+        isPlaying = false
+        abandonAudioFocus()
+        audioTrack?.let { track ->
+            runCatching { track.pause() }
+            runCatching { track.flush() }
+            runCatching { track.stop() }
+        }
+        windows.clear()
+        executor.shutdownNow()
+    }
+
+    private fun decodeWindows() {
+        try {
+            var windowEndUs = startPositionUs
+            while (windowEndUs > 0 && !stopped.get()) {
+                val windowStartUs = (windowEndUs - WINDOW_DURATION_US).coerceAtLeast(0)
+                val window = decodeWindow(windowStartUs, windowEndUs)
+                if (window.pcm.isNotEmpty() && !offer(WindowItem(window))) {
+                    return
+                }
+                windowEndUs = windowStartUs
+            }
+            offer(EndItem)
+        } catch (error: Throwable) {
+            if (!stopped.get()) {
+                offer(ErrorItem(error))
+            }
+        }
+    }
+
+    private fun decodeWindow(startUs: Long, endUs: Long): DecodedWindow {
+        val extractor = MediaExtractor()
+        var codec: MediaCodec? = null
+        try {
+            extractor.setDataSource(context, uri, null)
+            val trackIndex =
+                (0 until extractor.trackCount).firstOrNull { index ->
+                    extractor
+                        .getTrackFormat(index)
+                        .getString(MediaFormat.KEY_MIME)
+                        ?.startsWith("audio/") == true
+                } ?: throw IllegalArgumentException("Uri has no decodable audio track: $uri")
+            extractor.selectTrack(trackIndex)
+            extractor.seekTo(startUs, MediaExtractor.SEEK_TO_PREVIOUS_SYNC)
+
+            val inputFormat = extractor.getTrackFormat(trackIndex)
+            val mime =
+                inputFormat.getString(MediaFormat.KEY_MIME)
+                    ?: throw IllegalArgumentException("Audio track has no MIME type")
+            inputFormat.setInteger(MediaFormat.KEY_PCM_ENCODING, AudioFormat.ENCODING_PCM_16BIT)
+            codec = MediaCodec.createDecoderByType(mime)
+            codec.configure(inputFormat, null, null, 0)
+            codec.start()
+
+            var outputSampleRate = inputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+            var outputChannelCount = inputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+            var outputChannelMask =
+                if (inputFormat.containsKey(MediaFormat.KEY_CHANNEL_MASK)) {
+                    inputFormat.getInteger(MediaFormat.KEY_CHANNEL_MASK)
+                } else {
+                    channelMask(outputChannelCount)
+                }
+            val pcm = ByteArrayOutputStream()
+            val info = MediaCodec.BufferInfo()
+            var inputEnded = false
+            var outputEnded = false
+            while (!outputEnded && !stopped.get()) {
+                if (!inputEnded) {
+                    val inputIndex = codec.dequeueInputBuffer(CODEC_TIMEOUT_US)
+                    if (inputIndex >= 0) {
+                        val inputBuffer = requireNotNull(codec.getInputBuffer(inputIndex))
+                        val sampleTimeUs = extractor.sampleTime
+                        if (sampleTimeUs < 0 || sampleTimeUs >= endUs) {
+                            codec.queueInputBuffer(
+                                inputIndex,
+                                0,
+                                0,
+                                max(sampleTimeUs, endUs),
+                                MediaCodec.BUFFER_FLAG_END_OF_STREAM,
+                            )
+                            inputEnded = true
+                        } else {
+                            val size = extractor.readSampleData(inputBuffer, 0)
+                            if (size < 0) {
+                                codec.queueInputBuffer(
+                                    inputIndex,
+                                    0,
+                                    0,
+                                    endUs,
+                                    MediaCodec.BUFFER_FLAG_END_OF_STREAM,
+                                )
+                                inputEnded = true
+                            } else {
+                                codec.queueInputBuffer(inputIndex, 0, size, sampleTimeUs, 0)
+                                extractor.advance()
+                            }
+                        }
+                    }
+                }
+
+                when (val outputIndex = codec.dequeueOutputBuffer(info, CODEC_TIMEOUT_US)) {
+                    MediaCodec.INFO_OUTPUT_FORMAT_CHANGED -> {
+                        val outputFormat = codec.outputFormat
+                        val encoding =
+                            if (outputFormat.containsKey(MediaFormat.KEY_PCM_ENCODING)) {
+                                outputFormat.getInteger(MediaFormat.KEY_PCM_ENCODING)
+                            } else {
+                                AudioFormat.ENCODING_PCM_16BIT
+                            }
+                        check(encoding == AudioFormat.ENCODING_PCM_16BIT) {
+                            "Decoder produced unsupported PCM encoding $encoding"
+                        }
+                        outputSampleRate = outputFormat.getInteger(MediaFormat.KEY_SAMPLE_RATE)
+                        outputChannelCount = outputFormat.getInteger(MediaFormat.KEY_CHANNEL_COUNT)
+                        outputChannelMask =
+                            if (outputFormat.containsKey(MediaFormat.KEY_CHANNEL_MASK)) {
+                                outputFormat.getInteger(MediaFormat.KEY_CHANNEL_MASK)
+                            } else {
+                                channelMask(outputChannelCount)
+                            }
+                    }
+                    in 0..Int.MAX_VALUE -> {
+                        val outputBuffer = requireNotNull(codec.getOutputBuffer(outputIndex))
+                        if (
+                            info.size > 0 && info.flags and MediaCodec.BUFFER_FLAG_CODEC_CONFIG == 0
+                        ) {
+                            appendClippedPcm(
+                                pcm,
+                                outputBuffer,
+                                info,
+                                outputSampleRate,
+                                outputChannelCount,
+                                startUs,
+                                endUs,
+                            )
+                        }
+                        outputEnded = info.flags and MediaCodec.BUFFER_FLAG_END_OF_STREAM != 0
+                        codec.releaseOutputBuffer(outputIndex, false)
+                    }
+                }
+            }
+
+            val frameSize = outputChannelCount * PCM_BYTES_PER_SAMPLE
+            val bytes = pcm.toByteArray().copyOf(pcm.size() - pcm.size() % frameSize)
+            amplifyPcm(bytes, amplification)
+            reversePcmFrames(bytes, frameSize)
+            return DecodedWindow(bytes, outputSampleRate, outputChannelCount, outputChannelMask)
+        } finally {
+            codec?.let {
+                runCatching { it.stop() }
+                it.release()
+            }
+            extractor.release()
+        }
+    }
+
+    private fun playWindows(onEnded: () -> Unit, onError: (Throwable) -> Unit) {
+        var track: AudioTrack? = null
+        var submittedFrames = 0L
+        var outputChannelMask = 0
+        try {
+            while (!stopped.get()) {
+                when (val item = windows.poll(QUEUE_WAIT_MS, TimeUnit.MILLISECONDS)) {
+                    null -> Unit
+                    is WindowItem -> {
+                        val window = item.window
+                        if (track == null) {
+                            val newTrack = createAudioTrack(window)
+                            if (stopped.get()) {
+                                newTrack.release()
+                                return
+                            }
+                            track = newTrack
+                            audioTrack = track
+                            sampleRate = window.sampleRate
+                            outputChannelMask = window.channelMask
+                            if (!focusSuspended) {
+                                track.play()
+                                isPlaying = true
+                            }
+                            postPlaybackChanged()
+                        } else {
+                            check(
+                                sampleRate == window.sampleRate &&
+                                    track.channelCount == window.channelCount &&
+                                    outputChannelMask == window.channelMask
+                            ) {
+                                "Audio format changed while decoding reverse audio"
+                            }
+                        }
+
+                        var offset = 0
+                        while (offset < window.pcm.size && !released.get()) {
+                            val written =
+                                track.write(
+                                    window.pcm,
+                                    offset,
+                                    window.pcm.size - offset,
+                                    AudioTrack.WRITE_BLOCKING,
+                                )
+                            check(written >= 0) { "AudioTrack write failed: $written" }
+                            offset += written
+                            submittedFrames +=
+                                written / (window.channelCount * PCM_BYTES_PER_SAMPLE)
+                        }
+                    }
+                    is ErrorItem -> throw item.error
+                    EndItem -> {
+                        if (track != null) {
+                            while (!released.get()) {
+                                val playedFrames = track.playbackHeadPosition.toLong() and UINT_MASK
+                                if (playedFrames >= submittedFrames) {
+                                    break
+                                }
+                                Thread.sleep(DRAIN_WAIT_MS)
+                            }
+                        }
+                        if (!released.get()) {
+                            finalPositionUs = 0
+                            isPlaying = false
+                            postEnded(onEnded)
+                        }
+                        return
+                    }
+                }
+            }
+        } catch (error: Throwable) {
+            if (!released.get()) {
+                finalPositionUs = currentPositionMs * 1000
+                isPlaying = false
+                postError(onError, error)
+            }
+        } finally {
+            stopped.set(true)
+            audioTrack = null
+            track?.let {
+                runCatching { it.stop() }
+                it.release()
+            }
+            executor.shutdownNow()
+        }
+    }
+
+    private fun createAudioTrack(window: DecodedWindow): AudioTrack {
+        val channelMask = window.channelMask
+        val minimumBufferSize =
+            AudioTrack.getMinBufferSize(
+                window.sampleRate,
+                channelMask,
+                AudioFormat.ENCODING_PCM_16BIT,
+            )
+        check(minimumBufferSize > 0) { "Unsupported AudioTrack format" }
+        val frameSize = window.channelCount * PCM_BYTES_PER_SAMPLE
+        val builder =
+            AudioTrack.Builder()
+                .setAudioAttributes(
+                    AudioAttributes.Builder()
+                        .setUsage(AudioAttributes.USAGE_MEDIA)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                        .build()
+                )
+                .setAudioFormat(
+                    AudioFormat.Builder()
+                        .setEncoding(AudioFormat.ENCODING_PCM_16BIT)
+                        .setSampleRate(window.sampleRate)
+                        .setChannelMask(channelMask)
+                        .build()
+                )
+                .setTransferMode(AudioTrack.MODE_STREAM)
+                .setBufferSizeInBytes(max(minimumBufferSize * 4, window.sampleRate * frameSize))
+        if (audioSessionId != AudioManager.AUDIO_SESSION_ID_GENERATE) {
+            builder.setSessionId(audioSessionId)
+        }
+        val track = builder.build()
+        try {
+            check(track.state == AudioTrack.STATE_INITIALIZED) { "Could not initialize AudioTrack" }
+            track.playbackParams =
+                track.playbackParams
+                    .setSpeed(speed)
+                    .setPitch(1f)
+                    .setAudioFallbackMode(android.media.PlaybackParams.AUDIO_FALLBACK_MODE_DEFAULT)
+            return track
+        } catch (error: Throwable) {
+            track.release()
+            throw error
+        }
+    }
+
+    @Suppress("DEPRECATION")
+    private fun requestAudioFocus(): Boolean {
+        val result =
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                val request =
+                    AudioFocusRequest.Builder(AudioManager.AUDIOFOCUS_GAIN)
+                        .setAudioAttributes(
+                            AudioAttributes.Builder()
+                                .setUsage(AudioAttributes.USAGE_MEDIA)
+                                .setContentType(AudioAttributes.CONTENT_TYPE_MUSIC)
+                                .build()
+                        )
+                        .setOnAudioFocusChangeListener(audioFocusListener, mainHandler)
+                        .setWillPauseWhenDucked(true)
+                        .build()
+                audioFocusRequest = request
+                audioManager.requestAudioFocus(request)
+            } else {
+                audioManager.requestAudioFocus(
+                    audioFocusListener,
+                    AudioManager.STREAM_MUSIC,
+                    AudioManager.AUDIOFOCUS_GAIN,
+                )
+            }
+        hasAudioFocus = result == AudioManager.AUDIOFOCUS_REQUEST_GRANTED
+        return hasAudioFocus
+    }
+
+    @Suppress("DEPRECATION")
+    private fun abandonAudioFocus() {
+        if (!hasAudioFocus) {
+            return
+        }
+        hasAudioFocus = false
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            audioFocusRequest?.let(audioManager::abandonAudioFocusRequest)
+        } else {
+            audioManager.abandonAudioFocus(audioFocusListener)
+        }
+        audioFocusRequest = null
+        playbackChangedCallback = null
+        errorCallback = null
+    }
+
+    private fun postPlaybackChanged() {
+        val callback = playbackChangedCallback ?: return
+        mainHandler.post {
+            if (!released.get()) {
+                callback()
+            }
+        }
+    }
+
+    private fun offer(item: QueueItem): Boolean {
+        while (!stopped.get()) {
+            if (windows.offer(item, QUEUE_WAIT_MS, TimeUnit.MILLISECONDS)) {
+                return true
+            }
+        }
+        return false
+    }
+
+    private fun postEnded(callback: () -> Unit) {
+        if (callbackSent.compareAndSet(false, true)) {
+            mainHandler.post {
+                if (!released.get()) {
+                    callback()
+                }
+            }
+        }
+    }
+
+    private fun postError(callback: (Throwable) -> Unit, error: Throwable) {
+        if (callbackSent.compareAndSet(false, true)) {
+            mainHandler.post {
+                if (!released.get()) {
+                    callback(error)
+                }
+            }
+        }
+    }
+
+    private sealed interface QueueItem
+
+    private class WindowItem(val window: DecodedWindow) : QueueItem
+
+    private class ErrorItem(val error: Throwable) : QueueItem
+
+    private object EndItem : QueueItem
+
+    private class DecodedWindow(
+        val pcm: ByteArray,
+        val sampleRate: Int,
+        val channelCount: Int,
+        val channelMask: Int,
+    )
+
+    private companion object {
+        const val WINDOW_DURATION_US = 2_500_000L
+        const val MICROS_PER_SECOND = 1_000_000L
+        const val CODEC_TIMEOUT_US = 10_000L
+        const val QUEUE_WAIT_MS = 100L
+        const val DRAIN_WAIT_MS = 10L
+        const val WINDOW_QUEUE_SIZE = 3
+        const val PCM_BYTES_PER_SAMPLE = 2
+        const val UINT_MASK = 0xffffffffL
+
+        fun appendClippedPcm(
+            destination: ByteArrayOutputStream,
+            source: ByteBuffer,
+            info: MediaCodec.BufferInfo,
+            sampleRate: Int,
+            channelCount: Int,
+            startUs: Long,
+            endUs: Long,
+        ) {
+            val frameSize = channelCount * PCM_BYTES_PER_SAMPLE
+            val frameCount = info.size / frameSize
+            val firstFrame =
+                if (startUs <= info.presentationTimeUs) {
+                        0
+                    } else {
+                        framesAtOrAfter(startUs - info.presentationTimeUs, sampleRate)
+                    }
+                    .coerceAtMost(frameCount)
+            val lastFrame =
+                if (endUs <= info.presentationTimeUs) {
+                        0
+                    } else {
+                        framesAtOrAfter(endUs - info.presentationTimeUs, sampleRate)
+                    }
+                    .coerceAtMost(frameCount)
+            if (lastFrame <= firstFrame) {
+                return
+            }
+
+            val byteCount = (lastFrame - firstFrame) * frameSize
+            val bytes = ByteArray(byteCount)
+            source.position(info.offset + firstFrame * frameSize)
+            source.get(bytes)
+            destination.write(bytes)
+        }
+
+        private fun framesAtOrAfter(durationUs: Long, sampleRate: Int): Int =
+            ((durationUs * sampleRate + MICROS_PER_SECOND - 1) / MICROS_PER_SECOND)
+                .coerceAtMost(Int.MAX_VALUE.toLong())
+                .toInt()
+
+        private fun channelMask(channelCount: Int): Int =
+            when (channelCount) {
+                1 -> AudioFormat.CHANNEL_OUT_MONO
+                2 -> AudioFormat.CHANNEL_OUT_STEREO
+                3 -> AudioFormat.CHANNEL_OUT_STEREO or AudioFormat.CHANNEL_OUT_FRONT_CENTER
+                4 -> AudioFormat.CHANNEL_OUT_QUAD
+                5 -> AudioFormat.CHANNEL_OUT_QUAD or AudioFormat.CHANNEL_OUT_FRONT_CENTER
+                6 -> AudioFormat.CHANNEL_OUT_5POINT1
+                7 -> AudioFormat.CHANNEL_OUT_6POINT1
+                8 -> AudioFormat.CHANNEL_OUT_7POINT1_SURROUND
+                else -> throw IllegalArgumentException("Unsupported channel count $channelCount")
+            }
+    }
+}
+
+internal fun reversePcmFrames(pcm: ByteArray, frameSize: Int) {
+    require(frameSize > 0 && pcm.size % frameSize == 0)
+    var left = 0
+    var right = pcm.size - frameSize
+    while (left < right) {
+        for (offset in 0 until frameSize) {
+            val value = pcm[left + offset]
+            pcm[left + offset] = pcm[right + offset]
+            pcm[right + offset] = value
+        }
+        left += frameSize
+        right -= frameSize
+    }
+}
+
+internal fun amplifyPcm(pcm: ByteArray, amplification: Float) {
+    require(pcm.size % 2 == 0 && amplification.isFinite())
+    if (amplification == 1f) {
+        return
+    }
+    for (index in pcm.indices step 2) {
+        val sample = pcm[index].toInt().and(0xff).or(pcm[index + 1].toInt().shl(8)).toShort()
+        val amplified =
+            (sample * amplification)
+                .toInt()
+                .coerceIn(Short.MIN_VALUE.toInt(), Short.MAX_VALUE.toInt())
+        pcm[index] = amplified.toByte()
+        pcm[index + 1] = amplified.shr(8).toByte()
+    }
+}
+
+internal class ReverseAudioFocusLostException : IllegalStateException("Reverse audio lost focus")

--- a/app/src/main/java/org/oxycblt/auxio/playback/state/PlaybackStateHolder.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/state/PlaybackStateHolder.kt
@@ -69,6 +69,16 @@ interface PlaybackStateHolder {
     fun seekTo(positionMs: Long)
 
     /**
+     * Begin temporary scanning within the current track.
+     *
+     * Scanning must not cross track boundaries.
+     */
+    fun startScan(direction: ScanDirection)
+
+    /** Stop scanning and resume normal playback at the scanned position. */
+    fun stopScan()
+
+    /**
      * Update the repeat mode of the audio player.
      *
      * @param repeatMode The new repeat mode.
@@ -303,8 +313,12 @@ private constructor(
     private val isAdvancing: Boolean,
     /** The position when this instance was created, in milliseconds. */
     private val initPositionMs: Long,
-    /** The time this instance was created, as a unix epoch timestamp. */
+    /** The time this instance was created, as an elapsed realtime timestamp. */
     private val creationTime: Long,
+    /** Signed media-position change per second of elapsed time. */
+    val rate: Float,
+    /** Maximum valid position in this track. */
+    private val durationMs: Long,
 ) {
     /**
      * Calculate the "real" playback position this instance contains, in milliseconds.
@@ -312,14 +326,14 @@ private constructor(
      * @return If paused, the original position will be returned. Otherwise, it will be the original
      *   position plus the time elapsed since this state was created.
      */
-    fun calculateElapsedPositionMs() =
-        if (isAdvancing) {
-            initPositionMs + (SystemClock.elapsedRealtime() - creationTime)
-        } else {
-            // Not advancing due to buffering or some unrelated pausing, such as
-            // a transient audio focus change.
-            initPositionMs
+    fun calculateElapsedPositionMs(): Long {
+        if (!isAdvancing) {
+            return initPositionMs.coerceIn(0, durationMs)
         }
+
+        val elapsedMs = SystemClock.elapsedRealtime() - creationTime
+        return (initPositionMs + elapsedMs * rate).toLong().coerceIn(0, durationMs)
+    }
 
     /**
      * Load this instance into a [PlaybackStateCompat].
@@ -338,7 +352,7 @@ private constructor(
             },
             initPositionMs,
             if (isAdvancing) {
-                1f
+                rate
             } else {
                 // Not advancing, so don't move the position.
                 0f
@@ -353,12 +367,16 @@ private constructor(
         other is Progression &&
             isPlaying == other.isPlaying &&
             isAdvancing == other.isAdvancing &&
-            initPositionMs == other.initPositionMs
+            initPositionMs == other.initPositionMs &&
+            rate == other.rate &&
+            durationMs == other.durationMs
 
     override fun hashCode(): Int {
         var result = isPlaying.hashCode()
         result = 31 * result + isAdvancing.hashCode()
         result = 31 * result + initPositionMs.hashCode()
+        result = 31 * result + rate.hashCode()
+        result = 31 * result + durationMs.hashCode()
         return result
     }
 
@@ -371,13 +389,21 @@ private constructor(
          * @param isAdvancing Whether the player is actively playing audio in this moment.
          * @param positionMs The current position of the player.
          */
-        fun from(isPlaying: Boolean, isAdvancing: Boolean, positionMs: Long) =
+        fun from(
+            isPlaying: Boolean,
+            isAdvancing: Boolean,
+            positionMs: Long,
+            rate: Float,
+            durationMs: Long,
+        ) =
             Progression(
-                isPlaying,
+                isPlaying = isPlaying,
                 // Minor sanity check: Make sure that advancing can't occur if already paused.
-                isPlaying && isAdvancing,
-                positionMs,
-                SystemClock.elapsedRealtime(),
+                isAdvancing = isPlaying && isAdvancing,
+                initPositionMs = positionMs,
+                creationTime = SystemClock.elapsedRealtime(),
+                rate = rate,
+                durationMs = durationMs,
             )
 
         fun nil() =
@@ -386,6 +412,8 @@ private constructor(
                 isAdvancing = false,
                 initPositionMs = 0,
                 creationTime = SystemClock.elapsedRealtime(),
+                rate = 0f,
+                durationMs = 0,
             )
     }
 }

--- a/app/src/main/java/org/oxycblt/auxio/playback/state/PlaybackStateManager.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/state/PlaybackStateManager.kt
@@ -233,6 +233,12 @@ interface PlaybackStateManager {
      */
     fun seekTo(positionMs: Long)
 
+    /** Begin scanning within the currently playing [Song]. */
+    fun startScan(direction: ScanDirection)
+
+    /** Stop scanning and resume normal playback. */
+    fun stopScan()
+
     fun endSession()
 
     /**
@@ -449,6 +455,7 @@ class PlaybackStateManagerImpl @Inject constructor() : PlaybackStateManager {
     @Synchronized
     override fun play(command: PlaybackCommand) {
         val stateHolder = stateHolder ?: return
+        stateHolder.stopScan()
         L.d("Playing $command")
         // Played something, so we are initialized now
         isInitialized = true
@@ -460,6 +467,7 @@ class PlaybackStateManagerImpl @Inject constructor() : PlaybackStateManager {
     @Synchronized
     override fun next() {
         val stateHolder = stateHolder ?: return
+        stateHolder.stopScan()
         L.d("Going to next song")
         stateHolder.next()
     }
@@ -467,6 +475,7 @@ class PlaybackStateManagerImpl @Inject constructor() : PlaybackStateManager {
     @Synchronized
     override fun prev() {
         val stateHolder = stateHolder ?: return
+        stateHolder.stopScan()
         L.d("Going to previous song")
         stateHolder.prev()
     }
@@ -474,6 +483,7 @@ class PlaybackStateManagerImpl @Inject constructor() : PlaybackStateManager {
     @Synchronized
     override fun goto(index: Int) {
         val stateHolder = stateHolder ?: return
+        stateHolder.stopScan()
         L.d("Going to index $index")
         stateHolder.goto(index)
     }
@@ -518,6 +528,9 @@ class PlaybackStateManagerImpl @Inject constructor() : PlaybackStateManager {
     @Synchronized
     override fun removeQueueItem(at: Int) {
         val stateHolder = stateHolder ?: return
+        if (at == index) {
+            stateHolder.stopScan()
+        }
         L.d("Removing item at $at")
         stateHolder.remove(at, StateAck.Remove(at))
     }
@@ -556,6 +569,7 @@ class PlaybackStateManagerImpl @Inject constructor() : PlaybackStateManager {
     @Synchronized
     override fun playing(isPlaying: Boolean) {
         val stateHolder = stateHolder ?: return
+        stateHolder.stopScan()
         L.d("Updating playing state to $isPlaying")
         stateHolder.playing(isPlaying)
     }
@@ -563,6 +577,7 @@ class PlaybackStateManagerImpl @Inject constructor() : PlaybackStateManager {
     @Synchronized
     override fun repeatMode(repeatMode: RepeatMode) {
         val stateHolder = stateHolder ?: return
+        stateHolder.stopScan()
         L.d("Updating repeat mode to $repeatMode")
         stateHolder.repeatMode(repeatMode)
     }
@@ -570,13 +585,29 @@ class PlaybackStateManagerImpl @Inject constructor() : PlaybackStateManager {
     @Synchronized
     override fun seekTo(positionMs: Long) {
         val stateHolder = stateHolder ?: return
+        stateHolder.stopScan()
         L.d("Seeking to ${positionMs}ms")
         stateHolder.seekTo(positionMs)
     }
 
     @Synchronized
+    override fun startScan(direction: ScanDirection) {
+        val stateHolder = stateHolder ?: return
+        L.d("Starting $direction scan")
+        stateHolder.startScan(direction)
+    }
+
+    @Synchronized
+    override fun stopScan() {
+        val stateHolder = stateHolder ?: return
+        L.d("Stopping scan")
+        stateHolder.stopScan()
+    }
+
+    @Synchronized
     override fun endSession() {
         val stateHolder = stateHolder ?: return
+        stateHolder.stopScan()
         L.d("Ending session")
         stateHolder.endSession()
     }

--- a/app/src/main/java/org/oxycblt/auxio/playback/state/ScanDirection.kt
+++ b/app/src/main/java/org/oxycblt/auxio/playback/state/ScanDirection.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (c) 2026 Auxio Project
+ * ScanDirection.kt is part of Auxio.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.oxycblt.auxio.playback.state
+
+/** Direction and signed playback rate used while scanning through the current track. */
+enum class ScanDirection(val rate: Float) {
+    BACKWARD(-2f),
+    FORWARD(2f),
+}

--- a/app/src/test/java/org/oxycblt/auxio/playback/service/ReverseAudioEngineTest.kt
+++ b/app/src/test/java/org/oxycblt/auxio/playback/service/ReverseAudioEngineTest.kt
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2026 Auxio Project
+ * ReverseAudioEngineTest.kt is part of Auxio.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <https://www.gnu.org/licenses/>.
+ */
+ 
+package org.oxycblt.auxio.playback.service
+
+import org.junit.Assert.assertArrayEquals
+import org.junit.Test
+
+class ReverseAudioEngineTest {
+    @Test
+    fun reversePcmFrames_preservesInterleavedChannels() {
+        val pcm = byteArrayOf(1, 0, 2, 0, 3, 0, 4, 0, 5, 0, 6, 0)
+
+        reversePcmFrames(pcm, 4)
+
+        assertArrayEquals(byteArrayOf(5, 0, 6, 0, 3, 0, 4, 0, 1, 0, 2, 0), pcm)
+    }
+
+    @Test
+    fun amplifyPcm_clampsSamples() {
+        val pcm = byteArrayOf(0xff.toByte(), 0x7f, 0x00, 0x80.toByte(), 0xe8.toByte(), 0x03)
+
+        amplifyPcm(pcm, 2f)
+
+        assertArrayEquals(
+            byteArrayOf(0xff.toByte(), 0x7f, 0x00, 0x80.toByte(), 0xd0.toByte(), 0x07),
+            pcm,
+        )
+    }
+}


### PR DESCRIPTION
## Summary

- Preserve normal previous/next behavior for short taps.
- Fast-forward at 2x while holding the next button.
- Play decoded audio backward at 2x while holding the previous button.
- Restore the original playback state when the button is released.
- Keep scanning within the current track.
- Preserve ReplayGain, audio focus, audio effects, and media-session progression.
- Add tests for PCM frame reversal and amplification.

## Implementation

Forward scanning uses ExoPlayer's playback-speed support.

Reverse scanning uses a bounded MediaExtractor/MediaCodec pipeline that decodes PCM windows, reverses complete interleaved frames, and streams them through AudioTrack.

## Testing

- `./gradlew spotlessCheck`
- `./gradlew :app:testDebugUnitTest`
- `./gradlew :app:assembleDebug`
- Manual testing on: Google Pixel 9a

## Limitations

Reverse playback depends on Android's platform MediaCodec support. A format that Auxio can play only through its FFmpeg renderer may not support reverse scanning.

Closes #1413